### PR TITLE
Use predictiveBack enabled parameter

### DIFF
--- a/ui-app/src/androidMain/kotlin/com/alexvanyo/composelife/ui/app/InteractiveCellUniverse.kt
+++ b/ui-app/src/androidMain/kotlin/com/alexvanyo/composelife/ui/app/InteractiveCellUniverse.kt
@@ -209,20 +209,14 @@ fun rememberInteractiveCellUniverseState(
         }
     }
 
-    val infoCardExpandedPredictiveBackState = if (isInfoCardExpanded && !isActionCardTopCard) {
-        predictiveBackHandler {
+    val infoCardExpandedPredictiveBackState =
+        predictiveBackHandler(enabled = isInfoCardExpanded && !isActionCardTopCard) {
             setIsInfoCardExpanded(false)
         }
-    } else {
-        PredictiveBackState.NotRunning
-    }
-    val actionCardExpandedPredictiveBackState = if (isActionCardExpanded) {
-        predictiveBackHandler {
+    val actionCardExpandedPredictiveBackState =
+        predictiveBackHandler(enabled = isActionCardExpanded) {
             setIsActionCardExpanded(false)
         }
-    } else {
-        PredictiveBackState.NotRunning
-    }
 
     val infoCardState = rememberCellUniverseInfoCardState(
         setIsExpanded = ::setIsInfoCardExpanded,

--- a/ui-app/src/androidMain/kotlin/com/alexvanyo/composelife/ui/app/action/CellUniverseActionCardState.kt
+++ b/ui-app/src/androidMain/kotlin/com/alexvanyo/composelife/ui/app/action/CellUniverseActionCardState.kt
@@ -229,21 +229,19 @@ fun rememberCellUniverseActionCardState(
         }
     }
 
-    val predictiveBackState = if (enableBackHandler && expandedTargetState.current && canOuterNavigateBack) {
-        predictiveBackHandler {
+    val predictiveBackState =
+        predictiveBackHandler(
+            enabled = enableBackHandler && expandedTargetState.current && canOuterNavigateBack,
+        ) {
             onBackPressed(navController.currentEntryId)
         }
-    } else {
-        PredictiveBackState.NotRunning
-    }
 
-    val inlinePredictiveBackState = if (enableBackHandler && expandedTargetState.current && canInnerNavigateBack) {
-        predictiveBackHandler {
+    val inlinePredictiveBackState =
+        predictiveBackHandler(
+            enabled = enableBackHandler && expandedTargetState.current && canInnerNavigateBack,
+        ) {
             inlineOnBackPressed(inlineNavigationState.currentEntryId)
         }
-    } else {
-        PredictiveBackState.NotRunning
-    }
 
     return object : CellUniverseActionCardState {
 

--- a/ui-app/src/androidMain/kotlin/com/alexvanyo/composelife/ui/app/action/settings/FullscreenSettingsScreen.kt
+++ b/ui-app/src/androidMain/kotlin/com/alexvanyo/composelife/ui/app/action/settings/FullscreenSettingsScreen.kt
@@ -137,13 +137,10 @@ fun FullscreenSettingsScreen(
 
     fun showListAndDetail() = showList() && showDetail()
 
-    val predictiveBackState = if (showDetail() && !showList()) {
-        predictiveBackHandler {
+    val predictiveBackState =
+        predictiveBackHandler(enabled = showDetail() && !showList()) {
             fullscreen.showDetails = false
         }
-    } else {
-        PredictiveBackState.NotRunning
-    }
 
     val listContent = remember(fullscreen) {
         movableContentOf {


### PR DESCRIPTION
Uses the enabled parameter for predictiveBackHandler instead of removing it
from composition.

This preserves the hierarchical precedence of the back handling, since the
callbacks are tracked through time, instead of by hierarchy precedence,
so adding and removing them from composition can cause the precedence
to become out-of-sync from the hierarchy.