### PR TITLE
Use in-app setting as source of truth for system bar colors

### DIFF
--- a/app/src/androidMain/kotlin/com/alexvanyo/composelife/MainActivity.kt
+++ b/app/src/androidMain/kotlin/com/alexvanyo/composelife/MainActivity.kt
@@ -18,6 +18,7 @@ package com.alexvanyo.composelife
 
 import android.app.Activity
 import android.os.Bundle
+import androidx.activity.SystemBarStyle
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
@@ -61,7 +62,16 @@ class MainActivity : AppCompatActivity(), UiComponentOwner {
             with(mainActivityEntryPoint) {
                 val darkTheme = shouldUseDarkTheme()
                 DisposableEffect(darkTheme) {
-                    enableEdgeToEdge()
+                    enableEdgeToEdge(
+                        statusBarStyle = SystemBarStyle.auto(
+                            android.graphics.Color.TRANSPARENT,
+                            android.graphics.Color.TRANSPARENT,
+                        ) { darkTheme },
+                        navigationBarStyle = SystemBarStyle.auto(
+                            lightScrim,
+                            darkScrim,
+                        ) { darkTheme },
+                    )
                     onDispose {}
                 }
 
@@ -73,3 +83,15 @@ class MainActivity : AppCompatActivity(), UiComponentOwner {
         }
     }
 }
+
+/**
+* The default light scrim, as defined by androidx and the platform:
+* https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:activity/activity/src/main/java/androidx/activity/EdgeToEdge.kt;l=35-38;drc=27e7d52e8604a080133e8b842db10c89b4482598
+*/
+private val lightScrim = android.graphics.Color.argb(0xe6, 0xFF, 0xFF, 0xFF)
+
+/**
+ * The default dark scrim, as defined by androidx and the platform:
+ * https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:activity/activity/src/main/java/androidx/activity/EdgeToEdge.kt;l=40-44;drc=27e7d52e8604a080133e8b842db10c89b4482598
+ */
+private val darkScrim = android.graphics.Color.argb(0x80, 0x1b, 0x1b, 0x1b)


### PR DESCRIPTION
Previously, the direct `edgeToEdge` call assumes that the app's underlying configuration theme is precisely in sync with the in-app setting.

This could invite race conditions, so to be safe, avoid using the underlying configuration theme as a duplicated source of truth.