### PR TITLE
Replace GLSurfaceView with GLRenderer and AndroidExternalSurface

### DIFF
--- a/app/dependencies/releaseRuntimeClasspath.txt
+++ b/app/dependencies/releaseRuntimeClasspath.txt
@@ -73,7 +73,7 @@ androidx.emoji2:emoji2-views-helper:1.4.0
 androidx.emoji2:emoji2:1.4.0
 androidx.exifinterface:exifinterface:1.4.2
 androidx.fragment:fragment:1.5.4
-androidx.graphics:graphics-core:1.0.2
+androidx.graphics:graphics-core:1.0.3
 androidx.graphics:graphics-path:1.0.1
 androidx.graphics:graphics-shapes-android:1.1.0
 androidx.graphics:graphics-shapes:1.1.0

--- a/app/dependencies/releaseRuntimeClasspath.txt
+++ b/app/dependencies/releaseRuntimeClasspath.txt
@@ -73,6 +73,7 @@ androidx.emoji2:emoji2-views-helper:1.4.0
 androidx.emoji2:emoji2:1.4.0
 androidx.exifinterface:exifinterface:1.4.2
 androidx.fragment:fragment:1.5.4
+androidx.graphics:graphics-core:1.0.1
 androidx.graphics:graphics-path:1.0.1
 androidx.graphics:graphics-shapes-android:1.1.0
 androidx.graphics:graphics-shapes:1.1.0

--- a/app/dependencies/releaseRuntimeClasspath.txt
+++ b/app/dependencies/releaseRuntimeClasspath.txt
@@ -73,7 +73,7 @@ androidx.emoji2:emoji2-views-helper:1.4.0
 androidx.emoji2:emoji2:1.4.0
 androidx.exifinterface:exifinterface:1.4.2
 androidx.fragment:fragment:1.5.4
-androidx.graphics:graphics-core:1.0.1
+androidx.graphics:graphics-core:1.0.2
 androidx.graphics:graphics-path:1.0.1
 androidx.graphics:graphics-shapes-android:1.1.0
 androidx.graphics:graphics-shapes:1.1.0

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,7 +24,7 @@ androidxCoreSplashscreen = "1.2.0"
 #androidxDataStore
 androidxDataStore = "1.3.0-alpha09"
 #androidxGraphics
-androidxGraphics = "1.0.1"
+androidxGraphics = "1.0.2"
 #androidxLifecycle
 androidxLifecycle = "2.11.0"
 #androidxLintGradle

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,7 +24,7 @@ androidxCoreSplashscreen = "1.2.0"
 #androidxDataStore
 androidxDataStore = "1.3.0-alpha09"
 #androidxGraphics
-androidxGraphics = "1.0.2"
+androidxGraphics = "1.0.3"
 #androidxLifecycle
 androidxLifecycle = "2.11.0"
 #androidxLintGradle

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,6 +23,8 @@ androidxCore = "1.19.0"
 androidxCoreSplashscreen = "1.2.0"
 #androidxDataStore
 androidxDataStore = "1.3.0-alpha09"
+#androidxGraphics
+androidxGraphics = "1.0.1"
 #androidxLifecycle
 androidxLifecycle = "2.11.0"
 #androidxLintGradle
@@ -197,6 +199,7 @@ androidx-core-splashscreen = { group = "androidx.core", name = "core-splashscree
 androidx-dataStore = { group = "androidx.datastore", name = "datastore", version.ref = "androidxDataStore" }
 androidx-dataStore-core = { group = "androidx.datastore", name = "datastore-core", version.ref = "androidxDataStore" }
 androidx-dataStore-core-okio = { group = "androidx.datastore", name = "datastore-core-okio", version.ref = "androidxDataStore" }
+androidx-graphics-core = { group = "androidx.graphics", name = "graphics-core", version.ref = "androidxGraphics" }
 androidx-lifecycle-process = { group = "androidx.lifecycle", name = "lifecycle-process", version.ref = "androidxLifecycle" }
 androidx-lifecycle-runtime = { group = "androidx.lifecycle", name = "lifecycle-runtime", version.ref = "androidxLifecycle" }
 androidx-lifecycle-runtime-compose = { group = "androidx.lifecycle", name = "lifecycle-runtime-compose", version.ref = "androidxLifecycle" }

--- a/opengl-renderer/src/androidMain/kotlin/com/alexvanyo/composelife/openglrenderer/GameOfLifeShape.kt
+++ b/opengl-renderer/src/androidMain/kotlin/com/alexvanyo/composelife/openglrenderer/GameOfLifeShape.kt
@@ -261,8 +261,10 @@ class GameOfLifeShape(
 
     fun draw(mvpMatrix: FloatArray) {
         GLES20.glUseProgram(program)
+        checkOpenGLError()
 
         GLES20.glEnableVertexAttribArray(positionHandle)
+        checkOpenGLError()
 
         GLES20.glVertexAttribPointer(
             positionHandle,
@@ -272,8 +274,11 @@ class GameOfLifeShape(
             vertexStride,
             vertexBuffer,
         )
+        checkOpenGLError()
 
         GLES20.glUniformMatrix4fv(mvpMatrixHandle, 1, false, mvpMatrix, 0)
+        checkOpenGLError()
+        checkOpenGLFramebufferStatus()
 
         GLES20.glDrawElements(
             GLES20.GL_TRIANGLES,
@@ -281,6 +286,7 @@ class GameOfLifeShape(
             GLES20.GL_UNSIGNED_SHORT,
             drawListBuffer,
         )
+        checkOpenGLError()
 
         GLES20.glDisableVertexAttribArray(positionHandle)
         checkOpenGLError()

--- a/opengl-renderer/src/androidMain/kotlin/com/alexvanyo/composelife/openglrenderer/OpenGLUtils.kt
+++ b/opengl-renderer/src/androidMain/kotlin/com/alexvanyo/composelife/openglrenderer/OpenGLUtils.kt
@@ -30,6 +30,16 @@ fun checkOpenGLError() {
 }
 
 /**
+ * Throws if the framebuffer is not complete.
+ */
+fun checkOpenGLFramebufferStatus() {
+    val status = GLES20.glCheckFramebufferStatus(GLES20.GL_FRAMEBUFFER)
+    if (status != GLES20.GL_FRAMEBUFFER_COMPLETE) {
+        error("OpenGL framebuffer error: $status")
+    }
+}
+
+/**
  * Creates and compiles the given [shaderCode] of type [type].
  */
 fun loadShader(type: Int, shaderCode: String): Int =

--- a/ui-cells/build.gradle.kts
+++ b/ui-cells/build.gradle.kts
@@ -133,6 +133,7 @@ kotlin {
                 implementation(libs.androidx.compose.uiTooling)
                 implementation(libs.androidx.compose.uiUtil)
                 implementation(libs.androidx.core)
+                implementation(libs.androidx.graphics.core)
                 implementation(libs.androidx.lifecycle.runtime)
                 implementation(libs.androidx.poolingContainer)
                 implementation(libs.androidx.window)

--- a/ui-cells/src/androidMain/kotlin/com/alexvanyo/composelife/ui/cells/OpenGLNonInteractableCells.kt
+++ b/ui-cells/src/androidMain/kotlin/com/alexvanyo/composelife/ui/cells/OpenGLNonInteractableCells.kt
@@ -48,6 +48,7 @@ import com.alexvanyo.composelife.ui.mobile.ComposeLifeTheme
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.onEach
 import java.nio.IntBuffer
+import kotlin.concurrent.Volatile
 
 @Composable
 fun openGLSupported(): Boolean {
@@ -137,15 +138,14 @@ fun OpenGLNonInteractableCells(
                         surface: Surface,
                         width: Int,
                         height: Int,
-                    ): EGLSurface? {
-                        return super.onSurfaceCreated(spec, config, surface, width, height).also {
+                    ): EGLSurface? =
+                        super.onSurfaceCreated(spec, config, surface, width, height).also {
                             GLES20.glClearColor(0f, 0f, 0f, 0f)
                             GLES20.glViewport(0, 0, width, height)
                             gameOfLifeShape = GameOfLifeShape().apply {
                                 setSize(width, height)
                             }
                         }
-                    }
 
                     override fun onDrawFrame(eglManager: EGLManager) {
                         gameOfLifeShape.setScreenShapeParameters(parameters)

--- a/ui-cells/src/androidMain/kotlin/com/alexvanyo/composelife/ui/cells/OpenGLNonInteractableCells.kt
+++ b/ui-cells/src/androidMain/kotlin/com/alexvanyo/composelife/ui/cells/OpenGLNonInteractableCells.kt
@@ -45,6 +45,8 @@ import com.alexvanyo.composelife.model.CellWindow
 import com.alexvanyo.composelife.model.GameOfLifeState
 import com.alexvanyo.composelife.openglrenderer.GameOfLifeShape
 import com.alexvanyo.composelife.openglrenderer.GameOfLifeShapeParameters
+import com.alexvanyo.composelife.openglrenderer.checkOpenGLError
+import com.alexvanyo.composelife.openglrenderer.checkOpenGLFramebufferStatus
 import com.alexvanyo.composelife.preferences.CurrentShape
 import com.alexvanyo.composelife.ui.mobile.ComposeLifeTheme
 import kotlinx.coroutines.flow.collect
@@ -230,25 +232,5 @@ private fun OpenGLRepro() {
 
             renderTarget.requestRender()
         }
-    }
-}
-
-/**
- * Throws if there has been an OpenGL error.
- */
-fun checkOpenGLError() {
-    val error = GLES20.glGetError()
-    if (error != GLES20.GL_NO_ERROR) {
-        error("OpenGL error: $error")
-    }
-}
-
-/**
- * Throws if the framebuffer is not complete.
- */
-fun checkOpenGLFramebufferStatus() {
-    val status = GLES20.glCheckFramebufferStatus(GLES20.GL_FRAMEBUFFER)
-    if (status != GLES20.GL_FRAMEBUFFER_COMPLETE) {
-        error("OpenGL framebuffer error: $status")
     }
 }

--- a/ui-cells/src/androidMain/kotlin/com/alexvanyo/composelife/ui/cells/OpenGLNonInteractableCells.kt
+++ b/ui-cells/src/androidMain/kotlin/com/alexvanyo/composelife/ui/cells/OpenGLNonInteractableCells.kt
@@ -17,43 +17,37 @@
 package com.alexvanyo.composelife.ui.cells
 
 import android.app.ActivityManager
+import android.opengl.EGLConfig
+import android.opengl.EGLSurface
 import android.opengl.GLES20
-import android.opengl.GLSurfaceView
 import android.opengl.Matrix
+import android.view.Surface
+import androidx.compose.foundation.AndroidExternalSurface
+import androidx.compose.foundation.AndroidExternalSurfaceZOrder
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.RememberObserver
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Dp
-import androidx.compose.ui.viewinterop.AndroidView
 import androidx.core.content.getSystemService
-import androidx.core.view.isInvisible
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.compose.LocalLifecycleOwner
-import androidx.lifecycle.repeatOnLifecycle
+import androidx.graphics.opengl.GLRenderer
+import androidx.graphics.opengl.egl.EGLManager
+import androidx.graphics.opengl.egl.EGLSpec
 import com.alexvanyo.composelife.model.CellWindow
 import com.alexvanyo.composelife.model.GameOfLifeState
 import com.alexvanyo.composelife.openglrenderer.GameOfLifeShape
 import com.alexvanyo.composelife.openglrenderer.GameOfLifeShapeParameters
 import com.alexvanyo.composelife.preferences.CurrentShape
 import com.alexvanyo.composelife.ui.mobile.ComposeLifeTheme
-import com.alexvanyo.composelife.ui.util.LocalGhostElement
-import kotlinx.coroutines.asCoroutineDispatcher
-import kotlinx.coroutines.awaitCancellation
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.collect
-import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.onEach
-import kotlinx.coroutines.launch
 import java.nio.IntBuffer
-import java.util.concurrent.Executor
-import javax.microedition.khronos.egl.EGLConfig
-import javax.microedition.khronos.opengles.GL10
 
 @Composable
 fun openGLSupported(): Boolean {
@@ -92,32 +86,41 @@ fun OpenGLNonInteractableCells(
         buffer
     }
 
-    val parameters = when (shape) {
-        is CurrentShape.RoundRectangle -> {
-            GameOfLifeShapeParameters.RoundRectangle(
-                cells = cellsBuffer,
-                aliveColor = aliveColor,
-                deadColor = deadColor,
-                cellWindowSize = cellWindow.size,
-                scaledCellPixelSize = scaledCellPixelSize,
-                pixelOffsetFromCenter = pixelOffsetFromCenter,
-                sizeFraction = shape.sizeFraction,
-                cornerFraction = shape.cornerFraction,
-            )
-        }
-    }
+    val parameters by rememberUpdatedState(
+        when (shape) {
+            is CurrentShape.RoundRectangle -> {
+                GameOfLifeShapeParameters.RoundRectangle(
+                    cells = cellsBuffer,
+                    aliveColor = aliveColor,
+                    deadColor = deadColor,
+                    cellWindowSize = cellWindow.size,
+                    scaledCellPixelSize = scaledCellPixelSize,
+                    pixelOffsetFromCenter = pixelOffsetFromCenter,
+                    sizeFraction = shape.sizeFraction,
+                    cornerFraction = shape.cornerFraction,
+                )
+            }
+        },
+    )
 
-    val lifecycleOwner = LocalLifecycleOwner.current
-    val coroutineScope = rememberCoroutineScope()
+    val glRenderer = rememberGLRenderer()
 
-    val isGhostElement by rememberUpdatedState(LocalGhostElement.current)
+    AndroidExternalSurface(
+        modifier = modifier,
+        zOrder = if (inOverlay) {
+            AndroidExternalSurfaceZOrder.MediaOverlay
+        } else {
+            AndroidExternalSurfaceZOrder.Behind
+        },
+    ) {
+        onSurface { surface, width, height ->
+            val renderTarget = glRenderer.attach(
+                surface,
+                width,
+                height,
+                object : GLRenderer.RenderCallback {
+                    private lateinit var gameOfLifeShape: GameOfLifeShape
 
-    AndroidView(
-        factory = { context ->
-            object : GLSurfaceView(context) {
-                val parametersState = MutableStateFlow(parameters)
-
-                val renderer = object : Renderer {
                     private val mvpMatrix = FloatArray(16)
 
                     init {
@@ -128,64 +131,57 @@ fun OpenGLNonInteractableCells(
                         Matrix.multiplyMM(mvpMatrix, 0, projectionMatrix, 0, viewMatrix, 0)
                     }
 
-                    lateinit var gameOfLifeShape: GameOfLifeShape
-
-                    override fun onSurfaceCreated(unused: GL10?, config: EGLConfig?) {
-                        GLES20.glClearColor(0f, 0f, 0f, 0f)
-                        gameOfLifeShape = GameOfLifeShape()
-                        gameOfLifeShape.setScreenShapeParameters(parametersState.value)
+                    override fun onSurfaceCreated(
+                        spec: EGLSpec,
+                        config: EGLConfig,
+                        surface: Surface,
+                        width: Int,
+                        height: Int,
+                    ): EGLSurface? {
+                        return super.onSurfaceCreated(spec, config, surface, width, height).also {
+                            GLES20.glClearColor(0f, 0f, 0f, 0f)
+                            GLES20.glViewport(0, 0, width, height)
+                            gameOfLifeShape = GameOfLifeShape().apply {
+                                setSize(width, height)
+                            }
+                        }
                     }
 
-                    override fun onSurfaceChanged(unused: GL10?, width: Int, height: Int) {
-                        GLES20.glViewport(0, 0, width, height)
-                        gameOfLifeShape.setSize(width, height)
-                    }
-
-                    override fun onDrawFrame(unused: GL10?) {
+                    override fun onDrawFrame(eglManager: EGLManager) {
+                        gameOfLifeShape.setScreenShapeParameters(parameters)
                         gameOfLifeShape.draw(mvpMatrix)
                     }
+                },
+            )
 
-                    fun setParameters(parameters: GameOfLifeShapeParameters) {
-                        if (::gameOfLifeShape.isInitialized) {
-                            gameOfLifeShape.setScreenShapeParameters(parameters)
-                        }
-                    }
-                }
-            }.apply {
-                setEGLContextClientVersion(2)
-                setRenderer(renderer)
-                renderMode = GLSurfaceView.RENDERMODE_WHEN_DIRTY
-
-                val openGLExecutor = Executor(::queueEvent)
-                val openGLDispatcher = openGLExecutor.asCoroutineDispatcher()
-
-                coroutineScope.launch {
-                    parametersState
-                        .onEach(renderer::setParameters)
-                        .onEach { requestRender() }
-                        .flowOn(openGLDispatcher)
-                        .collect()
-                }
-
-                coroutineScope.launch {
-                    lifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
-                        onResume()
-                        try {
-                            awaitCancellation()
-                        } finally {
-                            onPause()
-                        }
-                    }
-                }
+            surface.onChanged { w, h ->
+                renderTarget.resize(w, h)
             }
-        },
-        update = {
-            it.parametersState.value = parameters
-            it.setZOrderMediaOverlay(inOverlay)
-            // The GLSurfaceView may not handling animating in and out well with externally applied alphas.
-            // If we are in a ghost element, skip showing it.
-            it.isInvisible = isGhostElement
-        },
-        modifier = modifier,
-    )
+
+            surface.onDestroyed {
+                glRenderer.detach(renderTarget, true)
+            }
+
+            snapshotFlow { parameters }
+                .onEach {
+                    renderTarget.requestRender()
+                }
+                .collect()
+        }
+    }
 }
+
+@Composable
+fun rememberGLRenderer(): GLRenderer =
+    remember {
+        object : RememberObserver {
+            val glRenderer = GLRenderer()
+            override fun onAbandoned() = onForgotten()
+            override fun onForgotten() {
+                glRenderer.stop(true)
+            }
+            override fun onRemembered() {
+                glRenderer.start()
+            }
+        }
+    }.glRenderer


### PR DESCRIPTION
Fixes #1838 

Current issues:

- [ ] Crashes when rotating on physical device: https://issuetracker.google.com/382607450
  ```
  2024-10-10 10:27:50.720 27061-27158 AndroidRuntime          com.alexvanyo.composelife            
  E  FATAL EXCEPTION: GLThread
                                                                                                      
  Process: com.alexvanyo.composelife, PID: 27061
                                                                                                    
  java.lang.IllegalStateException: OpenGL framebuffer error: 33305
                                                                                                    	 
  at B1.o.d(SourceFile:558)
                                                                                                    	 
  at B1.m.run(SourceFile:38)
                                                                                                    	 
  at android.os.Handler.handleCallback(Handler.java:959)
                                                                                                    	 
  at android.os.Handler.dispatchMessage(Handler.java:100)
                                                                                                    	 
  at android.os.Looper.loopOnce(Looper.java:232)
                                                                                                    	 
  at android.os.Looper.loop(Looper.java:317)
                                                                                                    	 
  at android.os.HandlerThread.run(HandlerThread.java:85)
  ```