### PR TITLE
Add `InputTransformation` restrictions to `EditableSlider` usages

### DIFF
--- a/ui-app/src/jbMain/kotlin/com/alexvanyo/composelife/ui/app/action/InlineSpeedPane.kt
+++ b/ui-app/src/jbMain/kotlin/com/alexvanyo/composelife/ui/app/action/InlineSpeedPane.kt
@@ -22,6 +22,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.input.InputTransformation
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
@@ -31,7 +32,6 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import com.alexvanyo.composelife.parameterizedstring.parameterizedStringResolver
 import com.alexvanyo.composelife.parameterizedstring.parameterizedStringResource
@@ -46,6 +46,8 @@ import com.alexvanyo.composelife.ui.app.resources.Strings
 import com.alexvanyo.composelife.ui.app.resources.TargetStepsPerSecondLabel
 import com.alexvanyo.composelife.ui.app.resources.TargetStepsPerSecondLabelAndValue
 import com.alexvanyo.composelife.ui.app.resources.TargetStepsPerSecondValue
+import com.alexvanyo.composelife.ui.util.nonNegativeDouble
+import com.alexvanyo.composelife.ui.util.nonNegativeLong
 import com.alexvanyo.composelife.ui.util.uuidSaver
 import com.benasher44.uuid.uuid4
 import kotlin.math.log2
@@ -136,6 +138,7 @@ fun TargetStepsPerSecondControl(
                 }
             }
         },
+        inputTransformation = InputTransformation.nonNegativeDouble(),
         modifier = modifier,
     )
 }
@@ -175,7 +178,7 @@ fun GenerationsPerStepControl(
             valueId = it.valueId
             setGenerationsPerStep(it.value)
         },
-        keyboardType = KeyboardType.Number,
+        inputTransformation = InputTransformation.nonNegativeLong(),
         modifier = modifier,
     )
 }

--- a/ui-app/src/jbMain/kotlin/com/alexvanyo/composelife/ui/app/action/settings/CellShapeConfigUi.kt
+++ b/ui-app/src/jbMain/kotlin/com/alexvanyo/composelife/ui/app/action/settings/CellShapeConfigUi.kt
@@ -20,6 +20,7 @@ package com.alexvanyo.composelife.ui.app.action.settings
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.text.input.InputTransformation
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -39,6 +40,7 @@ import com.alexvanyo.composelife.ui.app.resources.SizeFractionLabel
 import com.alexvanyo.composelife.ui.app.resources.SizeFractionLabelAndValue
 import com.alexvanyo.composelife.ui.app.resources.SizeFractionValue
 import com.alexvanyo.composelife.ui.app.resources.Strings
+import com.alexvanyo.composelife.ui.util.nonNegativeDouble
 import kotlinx.collections.immutable.toImmutableList
 
 interface CellShapeConfigUiInjectEntryPoint :
@@ -91,6 +93,7 @@ fun CellShapeConfigUi(
                     onSessionValueChange = currentShapeConfigUiState::onSizeFractionSessionValueChange,
                     valueRange = 0.1f..1f,
                     sliderBijection = Float.IdentitySliderBijection,
+                    inputTransformation = InputTransformation.nonNegativeDouble(),
                 )
 
                 EditableSlider(
@@ -102,6 +105,7 @@ fun CellShapeConfigUi(
                     onSessionValueChange = currentShapeConfigUiState::onCornerFractionSessionValueChange,
                     valueRange = 0f..0.5f,
                     sliderBijection = Float.IdentitySliderBijection,
+                    inputTransformation = InputTransformation.nonNegativeDouble(),
                 )
             }
         }

--- a/ui-app/src/jbMain/kotlin/com/alexvanyo/composelife/ui/app/component/EditableSlider.kt
+++ b/ui-app/src/jbMain/kotlin/com/alexvanyo/composelife/ui/app/component/EditableSlider.kt
@@ -19,6 +19,7 @@ package com.alexvanyo.composelife.ui.app.component
 import androidx.compose.foundation.focusable
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.text.input.InputTransformation
 import androidx.compose.foundation.text.input.TextFieldLineLimits
 import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.material3.SliderColors
@@ -39,10 +40,10 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.text.input.ImeAction
-import androidx.compose.ui.text.input.KeyboardType
 import com.alexvanyo.composelife.sessionvalue.SessionValue
 import com.alexvanyo.composelife.sessionvalue.localSessionId
 import com.alexvanyo.composelife.sessionvalue.rememberSessionValueHolder
+import com.alexvanyo.composelife.ui.util.nonNegativeDouble
 import com.benasher44.uuid.uuid4
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.filterNotNull
@@ -65,7 +66,7 @@ fun <T : Comparable<T>> EditableSlider(
     onValueChangeFinished: (() -> Unit)? = null,
     colors: SliderColors = SliderDefaults.colors(),
     sliderOverlay: @Composable () -> Unit = {},
-    keyboardType: KeyboardType = KeyboardType.Decimal,
+    inputTransformation: InputTransformation = InputTransformation.nonNegativeDouble(),
 ) {
     val value = sessionValue.value
 
@@ -165,9 +166,9 @@ fun <T : Comparable<T>> EditableSlider(
                 },
                 isError = transientValue == null,
                 keyboardOptions = KeyboardOptions(
-                    keyboardType = keyboardType,
                     imeAction = ImeAction.Done,
                 ),
+                inputTransformation = inputTransformation,
                 onKeyboardAction = { performDefaultAction ->
                     performDefaultAction()
                     sliderFocusRequester.requestFocus()

--- a/ui-common/src/jbMain/kotlin/com/alexvanyo/composelife/ui/util/NonNegativeDouble.kt
+++ b/ui-common/src/jbMain/kotlin/com/alexvanyo/composelife/ui/util/NonNegativeDouble.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alexvanyo.composelife.ui.util
+
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.text.input.InputTransformation
+import androidx.compose.foundation.text.input.TextFieldBuffer
+import androidx.compose.foundation.text.input.then
+import androidx.compose.ui.text.input.KeyboardType
+
+fun InputTransformation.nonNegativeDouble(): InputTransformation =
+    this.trimWhitespace().then(NonNegativeDouble)
+
+private object NonNegativeDouble : InputTransformation {
+    override val keyboardOptions: KeyboardOptions =
+        KeyboardOptions(
+            keyboardType = KeyboardType.Decimal,
+        )
+
+    override fun TextFieldBuffer.transformInput() {
+        val charSequence = asCharSequence()
+        if (charSequence.isNotEmpty()) {
+            val double = charSequence.toString().toDoubleOrNull()
+            if (double == null || double < 0f) {
+                revertAllChanges()
+            }
+        }
+    }
+}

--- a/ui-common/src/jbMain/kotlin/com/alexvanyo/composelife/ui/util/NonNegativeLong.kt
+++ b/ui-common/src/jbMain/kotlin/com/alexvanyo/composelife/ui/util/NonNegativeLong.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alexvanyo.composelife.ui.util
+
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.text.input.InputTransformation
+import androidx.compose.foundation.text.input.TextFieldBuffer
+import androidx.compose.foundation.text.input.then
+import androidx.compose.ui.text.input.KeyboardType
+
+fun InputTransformation.nonNegativeLong(): InputTransformation =
+    this.trimWhitespace().then(NonNegativeLong)
+
+private object NonNegativeLong : InputTransformation {
+    override val keyboardOptions: KeyboardOptions =
+        KeyboardOptions(
+            keyboardType = KeyboardType.Number,
+        )
+
+    override fun TextFieldBuffer.transformInput() {
+        val charSequence = asCharSequence()
+        if (charSequence.isNotEmpty()) {
+            val long = charSequence.toString().toLongOrNull()
+            if (long == null || long < 0) {
+                revertAllChanges()
+            }
+        }
+    }
+}

--- a/ui-common/src/jbMain/kotlin/com/alexvanyo/composelife/ui/util/TrimWhitespace.kt
+++ b/ui-common/src/jbMain/kotlin/com/alexvanyo/composelife/ui/util/TrimWhitespace.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alexvanyo.composelife.ui.util
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.text.input.InputTransformation
+import androidx.compose.foundation.text.input.TextFieldBuffer
+import androidx.compose.foundation.text.input.forEachChange
+import androidx.compose.foundation.text.input.then
+import androidx.compose.ui.text.substring
+
+fun InputTransformation.trimWhitespace(): InputTransformation =
+    this.then(TrimWhitespace)
+
+private object TrimWhitespace : InputTransformation {
+    @OptIn(ExperimentalFoundationApi::class)
+    override fun TextFieldBuffer.transformInput() {
+        changes.forEachChange { range, _ ->
+            if (!range.collapsed) {
+                replace(range.min, range.max, asCharSequence().substring(range).filterNot(Char::isWhitespace))
+            }
+        }
+    }
+}

--- a/ui-common/src/jbTest/kotlin/com/alexvanyo/composelife/ui/util/NonNegativeDoubleTests.kt
+++ b/ui-common/src/jbTest/kotlin/com/alexvanyo/composelife/ui/util/NonNegativeDoubleTests.kt
@@ -1,0 +1,255 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alexvanyo.composelife.ui.util
+
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.text.input.InputTransformation
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.foundation.text.input.insert
+import androidx.compose.foundation.text.input.placeCursorAtEnd
+import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.text.input.KeyboardType
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class NonNegativeDoubleTests {
+
+    private val textFieldState = TextFieldState()
+    private val inputTransformation = InputTransformation.nonNegativeDouble()
+
+    @Test
+    fun keyboard_options() {
+        assertEquals(
+            KeyboardOptions(
+                keyboardType = KeyboardType.Decimal,
+            ),
+            inputTransformation.keyboardOptions,
+        )
+    }
+
+    @Test
+    fun empty_string_with_no_changes() {
+        textFieldState.edit {
+            with(inputTransformation) {
+                transformInput()
+            }
+        }
+
+        assertEquals("", textFieldState.text)
+    }
+
+    @Test
+    fun empty_string_with_adding_space() {
+        textFieldState.edit {
+            append(" ")
+
+            with(inputTransformation) {
+                transformInput()
+            }
+        }
+
+        assertEquals("", textFieldState.text)
+    }
+
+    @Test
+    fun empty_string_with_adding_tab() {
+        textFieldState.edit {
+            append("\t")
+
+            with(inputTransformation) {
+                transformInput()
+            }
+        }
+
+        assertEquals("", textFieldState.text)
+    }
+
+    @Test
+    fun empty_string_with_adding_letter() {
+        textFieldState.edit {
+            append("a")
+
+            with(inputTransformation) {
+                transformInput()
+            }
+        }
+
+        assertEquals("", textFieldState.text)
+    }
+
+    @Test
+    fun empty_string_with_adding_digits() {
+        textFieldState.edit {
+            append("123")
+
+            with(inputTransformation) {
+                transformInput()
+            }
+        }
+
+        assertEquals("123", textFieldState.text)
+    }
+
+    @Test
+    fun empty_string_with_adding_digits_and_whitespace_after() {
+        textFieldState.edit {
+            append("12")
+            append(" ")
+            append("3")
+
+            with(inputTransformation) {
+                transformInput()
+            }
+        }
+
+        assertEquals("123", textFieldState.text)
+    }
+
+    @Test
+    fun empty_string_with_prepending_non_whitespace_and_whitespace_after() {
+        textFieldState.edit {
+            placeCursorAtEnd()
+            insert(0, "1")
+            insert(0, " ")
+            insert(0, "2")
+
+            with(inputTransformation) {
+                transformInput()
+            }
+        }
+
+        assertEquals("21", textFieldState.text)
+        assertEquals(TextRange(2), textFieldState.selection)
+    }
+
+    @Test
+    fun empty_string_with_prepending_number_and_negative() {
+        textFieldState.edit {
+            placeCursorAtEnd()
+            insert(0, "34")
+            insert(0, "-")
+
+            with(inputTransformation) {
+                transformInput()
+            }
+        }
+
+        assertEquals("", textFieldState.text)
+        assertEquals(TextRange(0), textFieldState.selection)
+    }
+
+
+    @Test
+    fun empty_string_with_prepending_number_and_positive() {
+        textFieldState.edit {
+            placeCursorAtEnd()
+            insert(0, "34")
+            insert(0, "+")
+
+            with(inputTransformation) {
+                transformInput()
+            }
+        }
+
+        assertEquals("+34", textFieldState.text)
+        assertEquals(TextRange(3), textFieldState.selection)
+    }
+
+    @Test
+    fun number_with_prepending_negative() {
+        textFieldState.edit {
+            append("34")
+        }
+
+        textFieldState.edit {
+            placeCursorAtEnd()
+            insert(0, "-")
+
+            with(inputTransformation) {
+                transformInput()
+            }
+        }
+
+        assertEquals("34", textFieldState.text)
+        assertEquals(TextRange(2), textFieldState.selection)
+    }
+
+    @Test
+    fun number_with_prepending_positive() {
+        textFieldState.edit {
+            append("34")
+        }
+
+        textFieldState.edit {
+            placeCursorAtEnd()
+            insert(0, "+")
+
+            with(inputTransformation) {
+                transformInput()
+            }
+        }
+
+        assertEquals("+34", textFieldState.text)
+        assertEquals(TextRange(3), textFieldState.selection)
+    }
+
+    @Test
+    fun empty_string_with_appending_decimal_point() {
+        textFieldState.edit {
+            append("34")
+            append(".")
+
+            with(inputTransformation) {
+                transformInput()
+            }
+        }
+
+        assertEquals("34.", textFieldState.text)
+    }
+
+    @Test
+    fun empty_string_with_appending_second_decimal_point() {
+        textFieldState.edit {
+            append("34")
+            append(".")
+            append(".")
+
+            with(inputTransformation) {
+                transformInput()
+            }
+        }
+
+        assertEquals("", textFieldState.text)
+    }
+
+    @Test
+    fun number_with_decimal_point_appending_second_decimal_point() {
+        textFieldState.edit {
+            append("34.")
+        }
+
+        textFieldState.edit {
+            append(".")
+
+            with(inputTransformation) {
+                transformInput()
+            }
+        }
+
+        assertEquals("34.", textFieldState.text)
+    }
+}

--- a/ui-common/src/jbTest/kotlin/com/alexvanyo/composelife/ui/util/NonNegativeLongTests.kt
+++ b/ui-common/src/jbTest/kotlin/com/alexvanyo/composelife/ui/util/NonNegativeLongTests.kt
@@ -1,0 +1,254 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alexvanyo.composelife.ui.util
+
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.text.input.InputTransformation
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.foundation.text.input.insert
+import androidx.compose.foundation.text.input.placeCursorAtEnd
+import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.text.input.KeyboardType
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class NonNegativeLongTests {
+
+    private val textFieldState = TextFieldState()
+    private val inputTransformation = InputTransformation.nonNegativeLong()
+
+    @Test
+    fun keyboard_options() {
+        assertEquals(
+            KeyboardOptions(
+                keyboardType = KeyboardType.Number,
+            ),
+            inputTransformation.keyboardOptions,
+        )
+    }
+
+    @Test
+    fun empty_string_with_no_changes() {
+        textFieldState.edit {
+            with(inputTransformation) {
+                transformInput()
+            }
+        }
+
+        assertEquals("", textFieldState.text)
+    }
+
+    @Test
+    fun empty_string_with_adding_space() {
+        textFieldState.edit {
+            append(" ")
+
+            with(inputTransformation) {
+                transformInput()
+            }
+        }
+
+        assertEquals("", textFieldState.text)
+    }
+
+    @Test
+    fun empty_string_with_adding_tab() {
+        textFieldState.edit {
+            append("\t")
+
+            with(inputTransformation) {
+                transformInput()
+            }
+        }
+
+        assertEquals("", textFieldState.text)
+    }
+
+    @Test
+    fun empty_string_with_adding_letter() {
+        textFieldState.edit {
+            append("a")
+
+            with(inputTransformation) {
+                transformInput()
+            }
+        }
+
+        assertEquals("", textFieldState.text)
+    }
+
+    @Test
+    fun empty_string_with_adding_digits() {
+        textFieldState.edit {
+            append("123")
+
+            with(inputTransformation) {
+                transformInput()
+            }
+        }
+
+        assertEquals("123", textFieldState.text)
+    }
+
+    @Test
+    fun empty_string_with_adding_digits_and_whitespace_after() {
+        textFieldState.edit {
+            append("12")
+            append(" ")
+            append("3")
+
+            with(inputTransformation) {
+                transformInput()
+            }
+        }
+
+        assertEquals("123", textFieldState.text)
+    }
+
+    @Test
+    fun empty_string_with_prepending_non_whitespace_and_whitespace_after() {
+        textFieldState.edit {
+            placeCursorAtEnd()
+            insert(0, "1")
+            insert(0, " ")
+            insert(0, "2")
+
+            with(inputTransformation) {
+                transformInput()
+            }
+        }
+
+        assertEquals("21", textFieldState.text)
+        assertEquals(TextRange(2), textFieldState.selection)
+    }
+
+    @Test
+    fun empty_string_with_prepending_number_and_negative() {
+        textFieldState.edit {
+            placeCursorAtEnd()
+            insert(0, "34")
+            insert(0, "-")
+
+            with(inputTransformation) {
+                transformInput()
+            }
+        }
+
+        assertEquals("", textFieldState.text)
+        assertEquals(TextRange(0), textFieldState.selection)
+    }
+
+    @Test
+    fun empty_string_with_prepending_number_and_positive() {
+        textFieldState.edit {
+            placeCursorAtEnd()
+            insert(0, "34")
+            insert(0, "+")
+
+            with(inputTransformation) {
+                transformInput()
+            }
+        }
+
+        assertEquals("+34", textFieldState.text)
+        assertEquals(TextRange(3), textFieldState.selection)
+    }
+
+    @Test
+    fun number_with_prepending_negative() {
+        textFieldState.edit {
+            append("34")
+        }
+
+        textFieldState.edit {
+            placeCursorAtEnd()
+            insert(0, "-")
+
+            with(inputTransformation) {
+                transformInput()
+            }
+        }
+
+        assertEquals("34", textFieldState.text)
+        assertEquals(TextRange(2), textFieldState.selection)
+    }
+
+    @Test
+    fun number_with_prepending_positive() {
+        textFieldState.edit {
+            append("34")
+        }
+
+        textFieldState.edit {
+            placeCursorAtEnd()
+            insert(0, "+")
+
+            with(inputTransformation) {
+                transformInput()
+            }
+        }
+
+        assertEquals("+34", textFieldState.text)
+        assertEquals(TextRange(3), textFieldState.selection)
+    }
+
+    @Test
+    fun empty_string_with_appending_decimal_point() {
+        textFieldState.edit {
+            append("34")
+            append(".")
+
+            with(inputTransformation) {
+                transformInput()
+            }
+        }
+
+        assertEquals("", textFieldState.text)
+    }
+
+    @Test
+    fun empty_string_with_appending_second_decimal_point() {
+        textFieldState.edit {
+            append("34")
+            append(".")
+            append(".")
+
+            with(inputTransformation) {
+                transformInput()
+            }
+        }
+
+        assertEquals("", textFieldState.text)
+    }
+
+    @Test
+    fun number_with_decimal_point_appending_second_decimal_point() {
+        textFieldState.edit {
+            append("34")
+        }
+
+        textFieldState.edit {
+            append(".")
+
+            with(inputTransformation) {
+                transformInput()
+            }
+        }
+
+        assertEquals("34", textFieldState.text)
+    }
+}

--- a/ui-common/src/jbTest/kotlin/com/alexvanyo/composelife/ui/util/TrimWhitespaceTests.kt
+++ b/ui-common/src/jbTest/kotlin/com/alexvanyo/composelife/ui/util/TrimWhitespaceTests.kt
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alexvanyo.composelife.ui.util
+
+import androidx.compose.foundation.text.input.InputTransformation
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.foundation.text.input.insert
+import androidx.compose.foundation.text.input.placeCursorAtEnd
+import androidx.compose.ui.text.TextRange
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class TrimWhitespaceTests {
+
+    private val textFieldState = TextFieldState()
+    private val inputTransformation = InputTransformation.trimWhitespace()
+
+    @Test
+    fun keyboard_options() {
+        assertEquals(
+            null,
+            inputTransformation.keyboardOptions,
+        )
+    }
+
+    @Test
+    fun empty_string_with_no_changes() {
+        textFieldState.edit {
+            with(inputTransformation) {
+                transformInput()
+            }
+        }
+
+        assertEquals("", textFieldState.text)
+    }
+
+    @Test
+    fun empty_string_with_adding_space() {
+        textFieldState.edit {
+            append(" ")
+
+            with(inputTransformation) {
+                transformInput()
+            }
+        }
+
+        assertEquals("", textFieldState.text)
+    }
+
+    @Test
+    fun empty_string_with_adding_tab() {
+        textFieldState.edit {
+            append("\t")
+
+            with(inputTransformation) {
+                transformInput()
+            }
+        }
+
+        assertEquals("", textFieldState.text)
+    }
+
+    @Test
+    fun empty_string_with_adding_non_whitespace() {
+        textFieldState.edit {
+            append("a")
+
+            with(inputTransformation) {
+                transformInput()
+            }
+        }
+
+        assertEquals("a", textFieldState.text)
+    }
+
+    @Test
+    fun empty_string_with_adding_non_whitespace_and_whitespace_together() {
+        textFieldState.edit {
+            append("a b")
+
+            with(inputTransformation) {
+                transformInput()
+            }
+        }
+
+        assertEquals("ab", textFieldState.text)
+    }
+
+    @Test
+    fun empty_string_with_adding_non_whitespace_and_whitespace_after() {
+        textFieldState.edit {
+            append("a")
+            append(" ")
+            append("b")
+
+            with(inputTransformation) {
+                transformInput()
+            }
+        }
+
+        assertEquals("ab", textFieldState.text)
+    }
+
+    @Test
+    fun empty_string_with_prepending_non_whitespace_and_whitespace_after() {
+        textFieldState.edit {
+            placeCursorAtEnd()
+            insert(0, "a")
+            insert(0, " ")
+            insert(0, "b")
+
+            with(inputTransformation) {
+                transformInput()
+            }
+        }
+
+        assertEquals("ba", textFieldState.text)
+        assertEquals(TextRange(2), textFieldState.selection)
+    }
+}


### PR DESCRIPTION
Fixes #2018
