### PR TITLE
Add test for drag and drop

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -41,6 +41,8 @@ androidxTestEspresso = "3.6.1"
 androidxTestExt = "1.2.1"
 #androidxTestRunner
 androidxTestRunner = "1.6.2"
+#androidxTestUiAutomator
+androidxTestUiAutomator = "2.4.0-alpha01"
 #androidxTracing
 androidxTracing = "1.3.0-alpha02"
 #androidxWearCompose
@@ -161,6 +163,7 @@ androidx-test-core = { group = "androidx.test", name = "core-ktx", version.ref =
 androidx-test-espresso = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "androidxTestEspresso" }
 androidx-test-junit = { group = "androidx.test.ext", name = "junit-ktx", version.ref = "androidxTestExt" }
 androidx-test-runner = { group = "androidx.test", name = "runner", version.ref = "androidxTestRunner" }
+androidx-test-uiAutomator = { group = "androidx.test.uiautomator", name = "uiautomator", version.ref = "androidxTestUiAutomator" }
 androidx-tracing = { group = "androidx.tracing", name = "tracing", version.ref = "androidxTracing" }
 androidx-wear-compose-foundation = { group = "androidx.wear.compose", name = "compose-foundation", version.ref = "androidxWearCompose" }
 androidx-wear-compose-material3 = { group = "androidx.wear.compose", name = "compose-material3", version.ref = "androidxWearComposeMaterial3" }

--- a/ui-app/build.gradle.kts
+++ b/ui-app/build.gradle.kts
@@ -172,6 +172,9 @@ kotlin {
         }
         val androidInstrumentedTest by getting {
             configurations["kspAndroidAndroidTest"].dependencies.add(libs.kotlinInject.ksp.get())
+            dependencies {
+                implementation(libs.androidx.test.uiAutomator)
+            }
         }
     }
 }

--- a/ui-app/src/androidInstrumentedTest/kotlin/com/alexvanyo/composelife/ui/app/action/LoadedCellStatePreviewTests.kt
+++ b/ui-app/src/androidInstrumentedTest/kotlin/com/alexvanyo/composelife/ui/app/action/LoadedCellStatePreviewTests.kt
@@ -47,9 +47,9 @@ import com.alexvanyo.composelife.test.runUiTest
 import com.alexvanyo.composelife.ui.app.TestComposeLifeApplicationComponent
 import com.alexvanyo.composelife.ui.app.TestComposeLifeUiComponent
 import com.alexvanyo.composelife.ui.app.createComponent
-import com.alexvanyo.composelife.ui.cells.cellStateDragAndDropTarget
 import com.alexvanyo.composelife.ui.cells.CellWindowInjectEntryPoint
 import com.alexvanyo.composelife.ui.cells.CellWindowLocalEntryPoint
+import com.alexvanyo.composelife.ui.cells.cellStateDragAndDropTarget
 import kotlinx.coroutines.test.runCurrent
 import org.junit.runner.RunWith
 import kotlin.test.Test
@@ -88,7 +88,7 @@ class LoadedCellStatePreviewTests : BaseUiInjectTest<TestComposeLifeApplicationC
                             onViewDeserializationInfo = {},
                             modifier = Modifier
                                 .testTag("LoadedCellStatePreview")
-                                .height(200.dp)
+                                .height(200.dp),
                         )
                     }
                 }
@@ -101,7 +101,7 @@ class LoadedCellStatePreviewTests : BaseUiInjectTest<TestComposeLifeApplicationC
                                 droppedCellState = it
                             }
                             .size(100.dp)
-                            .background(Color.Blue)
+                            .background(Color.Blue),
                     )
                 }
             }
@@ -168,4 +168,3 @@ class LoadedCellStatePreviewTests : BaseUiInjectTest<TestComposeLifeApplicationC
         assertEquals(GliderPattern.seedCellState, droppedCellState)
     }
 }
-

--- a/ui-app/src/androidInstrumentedTest/kotlin/com/alexvanyo/composelife/ui/app/action/LoadedCellStatePreviewTests.kt
+++ b/ui-app/src/androidInstrumentedTest/kotlin/com/alexvanyo/composelife/ui/app/action/LoadedCellStatePreviewTests.kt
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alexvanyo.composelife.ui.app.action
+
+import android.os.SystemClock
+import android.view.InputDevice
+import android.view.MotionEvent
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.longClick
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.unit.center
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.toOffset
+import androidx.test.platform.app.InstrumentationRegistry
+import com.alexvanyo.composelife.kmpandroidrunner.KmpAndroidJUnit4
+import com.alexvanyo.composelife.model.CellState
+import com.alexvanyo.composelife.model.CellStateFormat
+import com.alexvanyo.composelife.model.DeserializationResult
+import com.alexvanyo.composelife.model.di.CellStateParserProvider
+import com.alexvanyo.composelife.patterns.GliderPattern
+import com.alexvanyo.composelife.preferences.LoadedComposeLifePreferences
+import com.alexvanyo.composelife.test.BaseUiInjectTest
+import com.alexvanyo.composelife.test.runUiTest
+import com.alexvanyo.composelife.ui.app.TestComposeLifeApplicationComponent
+import com.alexvanyo.composelife.ui.app.TestComposeLifeUiComponent
+import com.alexvanyo.composelife.ui.app.createComponent
+import com.alexvanyo.composelife.ui.cells.cellStateDragAndDropTarget
+import com.alexvanyo.composelife.ui.cells.CellWindowInjectEntryPoint
+import com.alexvanyo.composelife.ui.cells.CellWindowLocalEntryPoint
+import kotlinx.coroutines.test.runCurrent
+import org.junit.runner.RunWith
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalTestApi::class)
+@RunWith(KmpAndroidJUnit4::class)
+class LoadedCellStatePreviewTests : BaseUiInjectTest<TestComposeLifeApplicationComponent, TestComposeLifeUiComponent>(
+    TestComposeLifeApplicationComponent::createComponent,
+    TestComposeLifeUiComponent::createComponent,
+) {
+    private val cellWindowLocalEntryPoint = object : CellWindowLocalEntryPoint {
+        override val preferences = LoadedComposeLifePreferences.Defaults
+    }
+
+    @Test
+    fun drag_and_drop_works_correctly() = runUiTest(applicationComponent.generalTestDispatcher) {
+        val cellWindowInjectEntryPoint: CellWindowInjectEntryPoint = uiComponent.entryPoint
+        val cellStateParserProvider: CellStateParserProvider = uiComponent.entryPoint
+
+        var droppedCellState: CellState? = null
+
+        setContent {
+            Column {
+                with(cellWindowLocalEntryPoint) {
+                    with(cellWindowInjectEntryPoint) {
+                        LoadedCellStatePreview(
+                            deserializationResult = DeserializationResult.Successful(
+                                cellState = GliderPattern.seedCellState,
+                                format = CellStateFormat.FixedFormat.Plaintext,
+                                warnings = emptyList(),
+                            ),
+                            isPinned = false,
+                            onPaste = {},
+                            onPinChanged = {},
+                            onViewDeserializationInfo = {},
+                            modifier = Modifier
+                                .testTag("LoadedCellStatePreview")
+                                .height(200.dp)
+                        )
+                    }
+                }
+
+                with(cellStateParserProvider) {
+                    Spacer(
+                        modifier = Modifier
+                            .testTag("TestDropTarget")
+                            .cellStateDragAndDropTarget {
+                                droppedCellState = it
+                            }
+                            .size(100.dp)
+                            .background(Color.Blue)
+                    )
+                }
+            }
+        }
+
+        val automation = InstrumentationRegistry.getInstrumentation().uiAutomation
+        val downTime = SystemClock.uptimeMillis()
+
+        val loadedCellStatePreviewCenter =
+            onNodeWithTag("LoadedCellStatePreview").fetchSemanticsNode().let { node ->
+                node.positionOnScreen + node.size.center.toOffset()
+            }
+        val testDropTargetCenter =
+            onNodeWithTag("TestDropTarget").fetchSemanticsNode().let { node ->
+                node.positionOnScreen + node.size.center.toOffset()
+            }
+
+        onNodeWithTag("LoadedCellStatePreview").performTouchInput {
+            longClick()
+            val down = MotionEvent.obtain(
+                downTime,
+                downTime,
+                MotionEvent.ACTION_DOWN,
+                loadedCellStatePreviewCenter.x.toFloat(),
+                loadedCellStatePreviewCenter.y.toFloat(),
+                0,
+            ).apply {
+                source = InputDevice.SOURCE_TOUCHSCREEN
+            }
+            automation.injectInputEvent(down, true)
+            down.recycle()
+        }
+
+        waitForIdle()
+
+        val move = MotionEvent.obtain(
+            downTime,
+            SystemClock.uptimeMillis(),
+            MotionEvent.ACTION_MOVE,
+            testDropTargetCenter.x.toFloat(),
+            testDropTargetCenter.y.toFloat(),
+            0,
+        ).apply {
+            source = InputDevice.SOURCE_TOUCHSCREEN
+        }
+        automation.injectInputEvent(move, true)
+        move.recycle()
+
+        val up = MotionEvent.obtain(
+            downTime,
+            SystemClock.uptimeMillis(),
+            MotionEvent.ACTION_UP,
+            testDropTargetCenter.x.toFloat(),
+            testDropTargetCenter.y.toFloat(),
+            0,
+        ).apply {
+            source = InputDevice.SOURCE_TOUCHSCREEN
+        }
+        automation.injectInputEvent(up, true)
+        up.recycle()
+
+        runCurrent()
+
+        assertEquals(GliderPattern.seedCellState, droppedCellState)
+    }
+}
+


### PR DESCRIPTION
By using `UiAutomation` in a very funky way interleaving with the normal Compose testing utils, I was able to get an automated test for platform-level drag-and-drop going through the end-to-end API surfaces.

Fixes #1938