### PR TITLE
Remove Guava for algorithm

### DIFF
--- a/algorithm/build.gradle.kts
+++ b/algorithm/build.gradle.kts
@@ -73,7 +73,6 @@ kotlin {
         val jvmMain by creating {
             dependsOn(commonMain)
             dependencies {
-                implementation(libs.guava.android)
                 implementation(libs.jetbrains.compose.uiUnit)
                 implementation(libs.sealedEnum.runtime)
             }

--- a/app/dependencies/releaseRuntimeClasspath.txt
+++ b/app/dependencies/releaseRuntimeClasspath.txt
@@ -153,9 +153,9 @@ com.google.ar:impress:0.0.2
 com.google.code.findbugs:jsr305:3.0.2
 com.google.errorprone:error_prone_annotations:2.30.0
 com.google.guava:failureaccess:1.0.1
-com.google.guava:guava:32.0.0-android
+com.google.guava:guava:31.0.1-android
 com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
-com.google.j2objc:j2objc-annotations:2.8
+com.google.j2objc:j2objc-annotations:1.3
 com.slack.circuit:circuit-retained-android:0.27.0
 com.slack.circuit:circuit-retained:0.27.0
 com.squareup.okhttp3:okhttp-sse:4.12.0
@@ -201,7 +201,8 @@ io.ktor:ktor-websockets:3.1.2
 io.reactivex.rxjava3:rxjava:3.0.2
 me.tatarka.inject:kotlin-inject-runtime-jvm:0.7.2
 me.tatarka.inject:kotlin-inject-runtime:0.7.2
-org.checkerframework:checker-qual:3.33.0
+org.checkerframework:checker-compat-qual:2.5.5
+org.checkerframework:checker-qual:3.12.0
 org.jetbrains.androidx.graphics:graphics-shapes:1.0.0-alpha03
 org.jetbrains.androidx.lifecycle:lifecycle-common:2.9.0-alpha03
 org.jetbrains.androidx.lifecycle:lifecycle-runtime-compose:2.9.0-alpha03

--- a/app/dependencies/releaseRuntimeClasspath.txt
+++ b/app/dependencies/releaseRuntimeClasspath.txt
@@ -153,9 +153,9 @@ com.google.ar:impress:0.0.2
 com.google.code.findbugs:jsr305:3.0.2
 com.google.errorprone:error_prone_annotations:2.30.0
 com.google.guava:failureaccess:1.0.1
-com.google.guava:guava:31.0.1-android
+com.google.guava:guava:32.0.0-android
 com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
-com.google.j2objc:j2objc-annotations:1.3
+com.google.j2objc:j2objc-annotations:2.8
 com.slack.circuit:circuit-retained-android:0.27.0
 com.slack.circuit:circuit-retained:0.27.0
 com.squareup.okhttp3:okhttp-sse:4.12.0
@@ -201,8 +201,7 @@ io.ktor:ktor-websockets:3.1.2
 io.reactivex.rxjava3:rxjava:3.0.2
 me.tatarka.inject:kotlin-inject-runtime-jvm:0.7.2
 me.tatarka.inject:kotlin-inject-runtime:0.7.2
-org.checkerframework:checker-compat-qual:2.5.5
-org.checkerframework:checker-qual:3.12.0
+org.checkerframework:checker-qual:3.33.0
 org.jetbrains.androidx.graphics:graphics-shapes:1.0.0-alpha03
 org.jetbrains.androidx.lifecycle:lifecycle-common:2.9.0-alpha03
 org.jetbrains.androidx.lifecycle:lifecycle-runtime-compose:2.9.0-alpha03

--- a/app/staging-test-proguard-rules.pro
+++ b/app/staging-test-proguard-rules.pro
@@ -23,6 +23,8 @@
 # Added due to dependency on Material via accessibility-test-framework
 -dontwarn androidx.appcompat.graphics.drawable.DrawableWrapper
 
+-dontwarn javax.lang.model.element.Modifier
+
 # Removing this causes a crash at runtime for some reason
 -keep class com.alexvanyo.composelife.ui.app.component.GameOfLifeProgressIndicatorInjectEntryPoint {
     *;

--- a/desktop-app/dependencies/desktopRuntimeClasspath.txt
+++ b/desktop-app/dependencies/desktopRuntimeClasspath.txt
@@ -42,12 +42,6 @@ co.touchlab:kermit-core:2.0.5
 co.touchlab:kermit-jvm:2.0.5
 co.touchlab:kermit:2.0.5
 com.github.livefront.sealed-enum:runtime:0.7.0
-com.google.code.findbugs:jsr305:3.0.2
-com.google.errorprone:error_prone_annotations:2.18.0
-com.google.guava:failureaccess:1.0.1
-com.google.guava:guava:32.0.0-android
-com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
-com.google.j2objc:j2objc-annotations:2.8
 com.slack.circuit:circuit-retained-jvm:0.27.0
 com.slack.circuit:circuit-retained:0.27.0
 com.squareup.okhttp3:okhttp-sse:4.12.0
@@ -88,7 +82,6 @@ io.ktor:ktor-websockets-jvm:3.1.2
 io.ktor:ktor-websockets:3.1.2
 me.tatarka.inject:kotlin-inject-runtime-jvm:0.7.2
 me.tatarka.inject:kotlin-inject-runtime:0.7.2
-org.checkerframework:checker-qual:3.33.0
 org.jetbrains.androidx.graphics:graphics-shapes:1.0.0-alpha03
 org.jetbrains.androidx.lifecycle:lifecycle-common:2.9.0-alpha03
 org.jetbrains.androidx.lifecycle:lifecycle-runtime-compose-desktop:2.9.0-alpha03

--- a/renovate.json
+++ b/renovate.json
@@ -18,12 +18,6 @@
       ]
     },
     {
-      "versioning": "docker",
-      "matchPackageNames": [
-        "/^com.google.guava/"
-      ]
-    },
-    {
       "matchDatasources": [
         "maven"
       ],

--- a/wear/dependencies/releaseRuntimeClasspath.txt
+++ b/wear/dependencies/releaseRuntimeClasspath.txt
@@ -145,12 +145,7 @@ co.touchlab:kermit:2.0.5
 com.airbnb.android:showkase-annotation:1.0.3
 com.airbnb.android:showkase:1.0.3
 com.github.livefront.sealed-enum:runtime:0.7.0
-com.google.code.findbugs:jsr305:3.0.2
-com.google.errorprone:error_prone_annotations:2.18.0
-com.google.guava:failureaccess:1.0.1
-com.google.guava:guava:32.0.0-android
-com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
-com.google.j2objc:j2objc-annotations:2.8
+com.google.guava:listenablefuture:1.0
 com.slack.circuit:circuit-retained-android:0.27.0
 com.slack.circuit:circuit-retained:0.27.0
 com.squareup.okio:okio-jvm:3.10.2
@@ -159,7 +154,6 @@ com.squareup.wire:wire-runtime-jvm:5.3.1
 com.squareup.wire:wire-runtime:5.3.1
 me.tatarka.inject:kotlin-inject-runtime-jvm:0.7.2
 me.tatarka.inject:kotlin-inject-runtime:0.7.2
-org.checkerframework:checker-qual:3.33.0
 org.jetbrains.androidx.lifecycle:lifecycle-common:2.9.0-alpha03
 org.jetbrains.androidx.lifecycle:lifecycle-runtime-compose:2.9.0-alpha03
 org.jetbrains.androidx.lifecycle:lifecycle-runtime:2.9.0-alpha03


### PR DESCRIPTION
Fixes #2274

Algorithm benchmarks before:
```
SM-F926U1 - 14 Tests 0/10 completed. (0 skipped) (0 failed)
  152,892,448   ns     1924768 allocs    Trace    Method Trace    GameOfLifeAlgorithmBenchmarks.generations_100[Naive Algorithm,Identity]
SM-F926U1 - 14 Tests 1/10 completed. (0 skipped) (0 failed)
  157,048,959   ns     1924964 allocs    Trace    Method Trace    GameOfLifeAlgorithmBenchmarks.generations_100[Naive Algorithm,Flip across x-axis]
SM-F926U1 - 14 Tests 2/10 completed. (0 skipped) (0 failed)
  151,218,177   ns     1925157 allocs    Trace    Method Trace    GameOfLifeAlgorithmBenchmarks.generations_100[Naive Algorithm,Flip across y-axis]
SM-F926U1 - 14 Tests 3/10 completed. (0 skipped) (0 failed)
  157,962,813   ns     1924771 allocs    Trace    Method Trace    GameOfLifeAlgorithmBenchmarks.generations_100[Naive Algorithm,Flip across x = y]
SM-F926U1 - 14 Tests 4/10 completed. (0 skipped) (0 failed)
  155,183,073   ns     1928085 allocs    Trace    Method Trace    GameOfLifeAlgorithmBenchmarks.generations_100[Naive Algorithm,Translate by an arbitrary amount]
SM-F926U1 - 14 Tests 5/10 completed. (0 skipped) (0 failed)
   30,623,203   ns      331848 allocs    Trace    Method Trace    GameOfLifeAlgorithmBenchmarks.generations_100[HashLife Algorithm,Identity]
SM-F926U1 - 14 Tests 6/10 completed. (0 skipped) (0 failed)
   32,832,317   ns      359480 allocs    Trace    Method Trace    GameOfLifeAlgorithmBenchmarks.generations_100[HashLife Algorithm,Flip across x-axis]
SM-F926U1 - 14 Tests 7/10 completed. (0 skipped) (0 failed)
   31,022,760   ns      341400 allocs    Trace    Method Trace    GameOfLifeAlgorithmBenchmarks.generations_100[HashLife Algorithm,Flip across y-axis]
SM-F926U1 - 14 Tests 8/10 completed. (0 skipped) (0 failed)
   30,300,313   ns      331757 allocs    Trace    Method Trace    GameOfLifeAlgorithmBenchmarks.generations_100[HashLife Algorithm,Flip across x = y]
SM-F926U1 - 14 Tests 9/10 completed. (0 skipped) (0 failed)
   30,414,504   ns      331885 allocs    Trace    Method Trace    GameOfLifeAlgorithmBenchmarks.generations_100[HashLife Algorithm,Translate by an arbitrary amount]
SM-F926U1 - 14 Tests 10/10 completed. (0 skipped) (0 failed)
```

Algorithm benchmarks after:
```
SM-F926U1 - 14 Tests 0/10 completed. (0 skipped) (0 failed)
  150,976,719   ns     1924769 allocs    Trace    Method Trace    GameOfLifeAlgorithmBenchmarks.generations_100[Naive Algorithm,Identity]
SM-F926U1 - 14 Tests 1/10 completed. (0 skipped) (0 failed)
  154,653,542   ns     1924963 allocs    Trace    Method Trace    GameOfLifeAlgorithmBenchmarks.generations_100[Naive Algorithm,Flip across x-axis]
SM-F926U1 - 14 Tests 2/10 completed. (0 skipped) (0 failed)
  157,130,780   ns     1925156 allocs    Trace    Method Trace    GameOfLifeAlgorithmBenchmarks.generations_100[Naive Algorithm,Flip across y-axis]
SM-F926U1 - 14 Tests 3/10 completed. (0 skipped) (0 failed)
  155,228,906   ns     1924768 allocs    Trace    Method Trace    GameOfLifeAlgorithmBenchmarks.generations_100[Naive Algorithm,Flip across x = y]
SM-F926U1 - 14 Tests 4/10 completed. (0 skipped) (0 failed)
  151,400,938   ns     1928078 allocs    Trace    Method Trace    GameOfLifeAlgorithmBenchmarks.generations_100[Naive Algorithm,Translate by an arbitrary amount]
SM-F926U1 - 14 Tests 5/10 completed. (0 skipped) (0 failed)
   28,158,264   ns      218168 allocs    Trace    Method Trace    GameOfLifeAlgorithmBenchmarks.generations_100[HashLife Algorithm,Identity]
SM-F926U1 - 14 Tests 6/10 completed. (0 skipped) (0 failed)
   22,432,291   ns      236205 allocs    Trace    Method Trace    GameOfLifeAlgorithmBenchmarks.generations_100[HashLife Algorithm,Flip across x-axis]
SM-F926U1 - 14 Tests 7/10 completed. (0 skipped) (0 failed)
   27,154,356   ns      224567 allocs    Trace    Method Trace    GameOfLifeAlgorithmBenchmarks.generations_100[HashLife Algorithm,Flip across y-axis]
SM-F926U1 - 14 Tests 8/10 completed. (0 skipped) (0 failed)
   21,079,045   ns      218207 allocs    Trace    Method Trace    GameOfLifeAlgorithmBenchmarks.generations_100[HashLife Algorithm,Flip across x = y]
SM-F926U1 - 14 Tests 9/10 completed. (0 skipped) (0 failed)
   21,867,226   ns      218204 allocs    Trace    Method Trace    GameOfLifeAlgorithmBenchmarks.generations_100[HashLife Algorithm,Translate by an arbitrary amount]

```