### PR TITLE
Remove suppressions for InjectDispatcher

### DIFF
--- a/algorithm/src/androidMain/kotlin/com/alexvanyo/composelife/model/CellStateParser.android.kt
+++ b/algorithm/src/androidMain/kotlin/com/alexvanyo/composelife/model/CellStateParser.android.kt
@@ -55,7 +55,6 @@ actual class CellStateParser(
         }
     }
 
-    @Suppress("InjectDispatcher")
     private suspend fun ClipData.Item.resolveToText(): CharSequence =
         withContext(dispatchers.IO) {
             coerceToText(context)

--- a/algorithm/src/jvmMain/kotlin/com/alexvanyo/composelife/algorithm/HashLifeAlgorithm.kt
+++ b/algorithm/src/jvmMain/kotlin/com/alexvanyo/composelife/algorithm/HashLifeAlgorithm.kt
@@ -295,7 +295,6 @@ class HashLifeAlgorithm(
         cellState: CellState,
         @IntRange(from = 0) step: Int,
     ): CellState =
-        @Suppress("InjectDispatcher") // Dispatchers are injected via dispatchers
         withContext(dispatchers.Default) {
             computeGenerationWithStepImpl(
                 cellState = cellState.toHashLifeCellState(),

--- a/algorithm/src/jvmMain/kotlin/com/alexvanyo/composelife/algorithm/NaiveGameOfLifeAlgorithm.kt
+++ b/algorithm/src/jvmMain/kotlin/com/alexvanyo/composelife/algorithm/NaiveGameOfLifeAlgorithm.kt
@@ -38,7 +38,6 @@ class NaiveGameOfLifeAlgorithm(
         cellState: CellState,
         @IntRange(from = 0) step: Int,
     ): CellState =
-        @Suppress("InjectDispatcher") // Dispatchers are injected via dispatchers
         withContext(dispatchers.Default) {
             computeGenerationWithStepImpl(
                 cellState = cellState,

--- a/data/src/jbMain/kotlin/com/alexvanyo/composelife/data/CellStateRepositoryImpl.kt
+++ b/data/src/jbMain/kotlin/com/alexvanyo/composelife/data/CellStateRepositoryImpl.kt
@@ -47,7 +47,6 @@ class CellStateRepositoryImpl(
                 )
                 .joinToString("\n")
 
-        @Suppress("InjectDispatcher")
         val insertedId: CellStateId = withContext(dispatchers.IO) {
             cellStateQueries.transactionWithResult {
                 if (saveableCellState.cellStateMetadata.id == null) {
@@ -79,7 +78,6 @@ class CellStateRepositoryImpl(
     }
 
     override suspend fun getAutosavedCellState(): SaveableCellState? {
-        @Suppress("InjectDispatcher")
         val cellState = withContext(dispatchers.IO) {
             cellStateQueries.getMostRecentAutosavedCellState().executeAsOneOrNull()
         } ?: return null

--- a/dispatchers-test/src/commonMain/kotlin/com/alexvanyo/composelife/dispatchers/TestComposeLifeDispatchers.kt
+++ b/dispatchers-test/src/commonMain/kotlin/com/alexvanyo/composelife/dispatchers/TestComposeLifeDispatchers.kt
@@ -30,7 +30,6 @@ import kotlin.coroutines.CoroutineContext
  *
  * [Unconfined] delegates to the default implementations, due to their custom behavior.
  */
-@Suppress("InjectDispatcher")
 @Inject
 @ContributesBinding(AppScope::class, replaces = [DefaultComposeLifeDispatchers::class])
 @SingleIn(AppScope::class)

--- a/dispatchers/src/commonMain/kotlin/com/alexvanyo/composelife/dispatchers/ComposeLifeDispatchers.kt
+++ b/dispatchers/src/commonMain/kotlin/com/alexvanyo/composelife/dispatchers/ComposeLifeDispatchers.kt
@@ -58,7 +58,6 @@ interface ComposeLifeDispatchers {
 /**
  * The default implementation of [ComposeLifeDispatchers], which just delegates to the normal [Dispatchers] versions.
  */
-@Suppress("InjectDispatcher")
 @Inject
 @ContributesBinding(AppScope::class)
 @SingleIn(AppScope::class)

--- a/preferences/src/androidMain/kotlin/com/alexvanyo/composelife/preferences/di/PreferencesDataStoreComponent.android.kt
+++ b/preferences/src/androidMain/kotlin/com/alexvanyo/composelife/preferences/di/PreferencesDataStoreComponent.android.kt
@@ -49,7 +49,6 @@ actual interface PreferencesDataStoreComponent {
     @Provides
     @SingleIn(AppScope::class)
     @PreferencesCoroutineScope
-    @Suppress("InjectDispatcher") // Dispatchers are injected via dispatchers
     fun providesPreferencesCoroutineScope(
         dispatchers: ComposeLifeDispatchers,
     ): CoroutineScope = CoroutineScope(

--- a/preferences/src/desktopMain/kotlin/com/alexvanyo/composelife/preferences/di/PreferencesDataStoreComponent.desktop.kt
+++ b/preferences/src/desktopMain/kotlin/com/alexvanyo/composelife/preferences/di/PreferencesDataStoreComponent.desktop.kt
@@ -45,7 +45,6 @@ actual interface PreferencesDataStoreComponent {
     @Provides
     @SingleIn(AppScope::class)
     @PreferencesCoroutineScope
-    @Suppress("InjectDispatcher") // Dispatchers are injected via dispatchers
     fun providesPreferencesCoroutineScope(
         dispatchers: ComposeLifeDispatchers,
     ): CoroutineScope = CoroutineScope(


### PR DESCRIPTION
The latest version of detekt fixes the false positives, so the existing
suppressions for InjectDispatcher can be removed.
