### PR TITLE
Change testBuildType for libraries to release

### DIFF
--- a/build-logic/convention/src/main/kotlin/AndroidLibraryConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidLibraryConventionPlugin.kt
@@ -34,7 +34,10 @@ class AndroidLibraryConventionPlugin : ConventionPlugin({
     extensions.configure<LibraryExtension> {
         configureAndroid(this)
 
-        testOptions.targetSdk = 35
+        testOptions {
+            targetSdk = 35
+            testBuildType = "release"
+        }
         lint.targetSdk = 35
         defaultConfig {
             consumerProguardFiles("consumer-rules.pro")

--- a/inject-test/src/androidMain/res/values/bools.xml
+++ b/inject-test/src/androidMain/res/values/bools.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+     Copyright 2025 The Android Open Source Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <bool name="leak_canary_allow_in_non_debuggable_build" tools:ignore="UnusedResources">true</bool>
+</resources>


### PR DESCRIPTION
This re-enables instrumented tests for library variants after switching the default from debug to release.