### PR TITLE
Remove global coroutine scope for DiskPreferencesDataStore

### DIFF
--- a/preferences/src/androidMain/kotlin/com/alexvanyo/composelife/preferences/di/PreferencesDataStoreBindings.android.kt
+++ b/preferences/src/androidMain/kotlin/com/alexvanyo/composelife/preferences/di/PreferencesDataStoreBindings.android.kt
@@ -19,17 +19,12 @@ package com.alexvanyo.composelife.preferences.di
 
 import android.content.Context
 import androidx.datastore.dataStoreFile
-import com.alexvanyo.composelife.dispatchers.ComposeLifeDispatchers
-import com.alexvanyo.composelife.preferences.PreferencesCoroutineScope
 import com.alexvanyo.composelife.preferences.PreferencesProtoPath
 import com.alexvanyo.composelife.scopes.ApplicationContext
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.BindingContainer
 import dev.zacsweers.metro.ContributesTo
 import dev.zacsweers.metro.Provides
-import dev.zacsweers.metro.SingleIn
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.SupervisorJob
 import okio.Path
 import okio.Path.Companion.toOkioPath
 
@@ -42,14 +37,5 @@ interface PreferencesDataStoreBindings {
         fun providesDataStorePath(
             @ApplicationContext context: Context,
         ): Path = context.dataStoreFile("preferences.pb").absoluteFile.toOkioPath()
-
-        @Provides
-        @SingleIn(AppScope::class)
-        @PreferencesCoroutineScope
-        fun providesPreferencesCoroutineScope(
-            dispatchers: ComposeLifeDispatchers,
-        ): CoroutineScope = CoroutineScope(
-            dispatchers.IO + SupervisorJob(),
-        )
     }
 }

--- a/preferences/src/desktopMain/kotlin/com/alexvanyo/composelife/preferences/di/PreferencesDataStoreBindings.desktop.kt
+++ b/preferences/src/desktopMain/kotlin/com/alexvanyo/composelife/preferences/di/PreferencesDataStoreBindings.desktop.kt
@@ -17,16 +17,11 @@
 
 package com.alexvanyo.composelife.preferences.di
 
-import com.alexvanyo.composelife.dispatchers.ComposeLifeDispatchers
-import com.alexvanyo.composelife.preferences.PreferencesCoroutineScope
 import com.alexvanyo.composelife.preferences.PreferencesProtoPath
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.BindingContainer
 import dev.zacsweers.metro.ContributesTo
 import dev.zacsweers.metro.Provides
-import dev.zacsweers.metro.SingleIn
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.SupervisorJob
 import okio.FileSystem
 import okio.Path
 
@@ -38,14 +33,5 @@ interface PreferencesDataStoreBindings {
         @PreferencesProtoPath
         fun providesDataStorePath(): Path =
             FileSystem.SYSTEM_TEMPORARY_DIRECTORY.resolve("preferences.pb")
-
-        @Provides
-        @SingleIn(AppScope::class)
-        @PreferencesCoroutineScope
-        fun providesPreferencesCoroutineScope(
-            dispatchers: ComposeLifeDispatchers,
-        ): CoroutineScope = CoroutineScope(
-            dispatchers.IO + SupervisorJob(),
-        )
     }
 }

--- a/preferences/src/jbMain/kotlin/com/alexvanyo/composelife/preferences/DefaultComposeLifePreferences.kt
+++ b/preferences/src/jbMain/kotlin/com/alexvanyo/composelife/preferences/DefaultComposeLifePreferences.kt
@@ -51,17 +51,17 @@ import kotlinx.datetime.DateTimePeriod
 @ContributesIntoSet(AppScope::class, binding = binding<Updatable>())
 @SingleIn(AppScope::class)
 class DefaultComposeLifePreferences(
-    preferencesDataStore: PreferencesDataStore,
+    private val preferencesDataStore: PreferencesDataStore,
     private val logger: Logger,
 ) : ComposeLifePreferences, Updatable {
-    private val dataStore = preferencesDataStore.dataStore
 
     override var loadedPreferencesState:
         ResourceState<LoadedComposeLifePreferences> by mutableStateOf(ResourceState.Loading)
         private set
 
     override suspend fun update(): Nothing {
-        dataStore.data
+        preferencesDataStore.getDataStore()
+            .data
             .map(PreferencesProto::toLoadedComposeLifePreferences)
             .asResourceState()
             .onEach {
@@ -86,7 +86,7 @@ class DefaultComposeLifePreferences(
     override suspend fun update(
         block: ComposeLifePreferencesTransform.() -> Unit,
     ) {
-        dataStore.updateData { preferencesProto ->
+        preferencesDataStore.getDataStore().updateData { preferencesProto ->
             PreferencesProtoTransform(preferencesProto).apply(block).newPreferencesProto
         }
     }

--- a/preferences/src/jbMain/kotlin/com/alexvanyo/composelife/preferences/DiskPreferencesDataStore.kt
+++ b/preferences/src/jbMain/kotlin/com/alexvanyo/composelife/preferences/DiskPreferencesDataStore.kt
@@ -78,20 +78,20 @@ class DiskPreferencesDataStore(
             storage = OkioStorage(
                 fileSystem = fileSystem,
                 serializer =
-                    object : OkioSerializer<PreferencesProto> {
-                        override val defaultValue: PreferencesProto
-                            get() = PreferencesProto()
+                object : OkioSerializer<PreferencesProto> {
+                    override val defaultValue: PreferencesProto
+                        get() = PreferencesProto()
 
-                        override suspend fun readFrom(source: BufferedSource): PreferencesProto =
-                            try {
-                                PreferencesProto.ADAPTER.decode(source)
-                            } catch (exception: IOException) {
-                                throw CorruptionException("Cannot read proto.", exception)
-                            }
+                    override suspend fun readFrom(source: BufferedSource): PreferencesProto =
+                        try {
+                            PreferencesProto.ADAPTER.decode(source)
+                        } catch (exception: IOException) {
+                            throw CorruptionException("Cannot read proto.", exception)
+                        }
 
-                        override suspend fun writeTo(t: PreferencesProto, sink: BufferedSink) =
-                            PreferencesProto.ADAPTER.encode(sink, t)
-                    },
+                    override suspend fun writeTo(t: PreferencesProto, sink: BufferedSink) =
+                        PreferencesProto.ADAPTER.encode(sink, t)
+                },
                 producePath = path::value,
             ),
             corruptionHandler = null,

--- a/preferences/src/jbMain/kotlin/com/alexvanyo/composelife/preferences/PreferencesDataStore.kt
+++ b/preferences/src/jbMain/kotlin/com/alexvanyo/composelife/preferences/PreferencesDataStore.kt
@@ -20,5 +20,5 @@ import androidx.datastore.core.DataStore
 import com.alexvanyo.composelife.preferences.proto.PreferencesProto
 
 interface PreferencesDataStore {
-    val dataStore: DataStore<PreferencesProto>
+    suspend fun getDataStore(): DataStore<PreferencesProto>
 }


### PR DESCRIPTION
This removes the injected `CoroutineScope` by instead providing the `DataStore` only via a suspending getter, and creating the `DataStore` using a `CoroutineScope` from an `AppScope`d `Updatable.update`.