### PR TITLE
Ignore CI-generated robolectric.properties only

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,5 +77,5 @@ lint/tmp/
 #Kotlin
 .kotlin/
 
-#robolectric.properties
-robolectric.properties
+#robolectric.properties generated in CI
+resources/com/alexvanyo/composelife/robolectric.properties


### PR DESCRIPTION
Fixes #2754
