### PR TITLE
Update Metro DI framework to 1.1.1

### DIFF
--- a/app/dependencies/releaseRuntimeClasspath.txt
+++ b/app/dependencies/releaseRuntimeClasspath.txt
@@ -174,8 +174,8 @@ com.squareup.okio:okio-jvm:3.17.0
 com.squareup.okio:okio:3.17.0
 com.squareup.wire:wire-runtime-jvm:6.2.0
 com.squareup.wire:wire-runtime:6.2.0
-dev.zacsweers.metro:runtime-jvm:1.0.0
-dev.zacsweers.metro:runtime:1.0.0
+dev.zacsweers.metro:runtime-jvm:1.1.1
+dev.zacsweers.metro:runtime:1.1.1
 io.coil-kt.coil3:coil-compose-core-android:3.4.0
 io.coil-kt.coil3:coil-compose-core:3.4.0
 io.coil-kt.coil3:coil-core-android:3.4.0

--- a/desktop-app/dependencies/desktopRuntimeClasspath.txt
+++ b/desktop-app/dependencies/desktopRuntimeClasspath.txt
@@ -68,8 +68,8 @@ com.squareup.okio:okio-jvm:3.17.0
 com.squareup.okio:okio:3.17.0
 com.squareup.wire:wire-runtime-jvm:6.2.0
 com.squareup.wire:wire-runtime:6.2.0
-dev.zacsweers.metro:runtime-jvm:1.0.0
-dev.zacsweers.metro:runtime:1.0.0
+dev.zacsweers.metro:runtime-jvm:1.1.1
+dev.zacsweers.metro:runtime:1.1.1
 io.coil-kt.coil3:coil-compose-core-jvm:3.4.0
 io.coil-kt.coil3:coil-compose-core:3.4.0
 io.coil-kt.coil3:coil-core-jvm:3.4.0

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -130,7 +130,7 @@ junit5 = "5.14.3"
 #leakCanary
 leakCanary = "3.0-alpha-8"
 #metro
-metro = "1.0.0"
+metro = "1.1.1"
 #molecule
 molecule = "2.2.0"
 #okio

--- a/wear/dependencies/releaseRuntimeClasspath.txt
+++ b/wear/dependencies/releaseRuntimeClasspath.txt
@@ -155,8 +155,8 @@ com.squareup.okio:okio-jvm:3.17.0
 com.squareup.okio:okio:3.17.0
 com.squareup.wire:wire-runtime-jvm:6.2.0
 com.squareup.wire:wire-runtime:6.2.0
-dev.zacsweers.metro:runtime-jvm:1.0.0
-dev.zacsweers.metro:runtime:1.0.0
+dev.zacsweers.metro:runtime-jvm:1.1.1
+dev.zacsweers.metro:runtime:1.1.1
 org.jetbrains.androidx.lifecycle:lifecycle-common:2.9.6
 org.jetbrains.androidx.lifecycle:lifecycle-runtime-compose:2.9.6
 org.jetbrains.androidx.lifecycle:lifecycle-runtime:2.9.6

--- a/web-app/dependencies/wasmJsRuntimeClasspath.txt
+++ b/web-app/dependencies/wasmJsRuntimeClasspath.txt
@@ -67,8 +67,8 @@ com.squareup.okio:okio-wasm-js:3.17.0
 com.squareup.okio:okio:3.17.0
 com.squareup.wire:wire-runtime-wasm-js:6.2.0
 com.squareup.wire:wire-runtime:6.2.0
-dev.zacsweers.metro:runtime-wasm-js:1.0.0
-dev.zacsweers.metro:runtime:1.0.0
+dev.zacsweers.metro:runtime-wasm-js:1.1.1
+dev.zacsweers.metro:runtime:1.1.1
 io.coil-kt.coil3:coil-compose-core-wasm-js:3.4.0
 io.coil-kt.coil3:coil-compose-core:3.4.0
 io.coil-kt.coil3:coil-core-wasm-js:3.4.0


### PR DESCRIPTION
Updates Metro dependency injection framework from 1.0.0 to the latest stable version 1.1.1. Also regenerates the tracked dependency baselines via dependencyGuardBaseline.