### PR TITLE
Fixes #3355: Add back allWarningsAsErrors to Kotlin configuration

### DIFF
--- a/app-impl/src/androidMain/kotlin/com/alexvanyo/composelife/MainActivity.kt
+++ b/app-impl/src/androidMain/kotlin/com/alexvanyo/composelife/MainActivity.kt
@@ -27,7 +27,7 @@ import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.foundation.layout.consumeWindowInsets
-import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
+import androidx.compose.material3.adaptive.currentWindowAdaptiveInfoV2
 import androidx.compose.material3.adaptive.currentWindowSize
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
@@ -167,7 +167,7 @@ class MainActivity : AppCompatActivity() {
                     ComposeLifeTheme(darkTheme) {
                         with(composeLifeAppUiCtx) {
                             ComposeLifeApp(
-                                windowSizeClass = currentWindowAdaptiveInfo().windowSizeClass,
+                                windowSizeClass = currentWindowAdaptiveInfoV2().windowSizeClass,
                                 windowSize = LocalWindowInfo.current.containerDpSize,
                             )
                         }

--- a/build-logic/convention/src/main/kotlin/com/alexvanyo/composelife/buildlogic/Kotlin.kt
+++ b/build-logic/convention/src/main/kotlin/com/alexvanyo/composelife/buildlogic/Kotlin.kt
@@ -27,6 +27,7 @@ fun Project.configureKotlin() {
             if (this is KotlinJvmCompilerOptions) {
                 jvmTarget.set(JvmTarget.JVM_11)
             }
+            allWarningsAsErrors.set(true)
             freeCompilerArgs.addAll(
                 "-Xreturn-value-checker=check",
                 "-Xexpect-actual-classes",

--- a/desktop-app/src/desktopMain/kotlin/com/alexvanyo/composelife/Main.kt
+++ b/desktop-app/src/desktopMain/kotlin/com/alexvanyo/composelife/Main.kt
@@ -16,7 +16,7 @@
 
 package com.alexvanyo.composelife
 
-import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
+import androidx.compose.material3.adaptive.currentWindowAdaptiveInfoV2
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -120,7 +120,7 @@ fun main() = application {
                     ComposeLifeTheme(shouldUseDarkTheme()) {
                         with(mainInjectCtx.composeLifeAppUiCtx) {
                             ComposeLifeApp(
-                                windowSizeClass = currentWindowAdaptiveInfo().windowSizeClass,
+                                windowSizeClass = currentWindowAdaptiveInfoV2().windowSizeClass,
                                 windowSize = windowState.size,
                             )
                         }

--- a/inject-test/src/androidMain/kotlin/com/alexvanyo/composelife/test/InjectTestRunner.kt
+++ b/inject-test/src/androidMain/kotlin/com/alexvanyo/composelife/test/InjectTestRunner.kt
@@ -34,13 +34,11 @@ class InjectTestRunner : AndroidJUnitRunner() {
         java.time.Instant.now()
         java.time.LocalDateTime.now()
         java.time.ZonedDateTime.now()
-        @Suppress("UNUSED_VARIABLE")
-        val zoneOffset = java.time.ZoneOffset.UTC
+        val _ = java.time.ZoneOffset.UTC
         java.time.Clock.systemUTC()
         java.time.Duration.ofDays(1)
         java.time.Period.ofDays(1)
-        @Suppress("UNUSED_VARIABLE")
-        val formatter = java.time.format.DateTimeFormatter.ISO_INSTANT
+        val _ = java.time.format.DateTimeFormatter.ISO_INSTANT
 
         return super.newApplication(cl, TestInjectApplication::class.java.name, context)
     }

--- a/inject-test/src/androidMain/kotlin/com/alexvanyo/composelife/test/InjectTestRunner.kt
+++ b/inject-test/src/androidMain/kotlin/com/alexvanyo/composelife/test/InjectTestRunner.kt
@@ -34,11 +34,13 @@ class InjectTestRunner : AndroidJUnitRunner() {
         java.time.Instant.now()
         java.time.LocalDateTime.now()
         java.time.ZonedDateTime.now()
-        java.time.ZoneOffset.UTC.toString()
+        @Suppress("UNUSED_VARIABLE")
+        val zoneOffset = java.time.ZoneOffset.UTC
         java.time.Clock.systemUTC()
         java.time.Duration.ofDays(1)
         java.time.Period.ofDays(1)
-        java.time.format.DateTimeFormatter.ISO_INSTANT.toString()
+        @Suppress("UNUSED_VARIABLE")
+        val formatter = java.time.format.DateTimeFormatter.ISO_INSTANT
 
         return super.newApplication(cl, TestInjectApplication::class.java.name, context)
     }

--- a/ui-app/src/androidSharedTest/kotlin/com/alexvanyo/composelife/ui/app/InteractiveCellUniverseTests.kt
+++ b/ui-app/src/androidSharedTest/kotlin/com/alexvanyo/composelife/ui/app/InteractiveCellUniverseTests.kt
@@ -17,7 +17,7 @@
 package com.alexvanyo.composelife.ui.app
 
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
+import androidx.compose.material3.adaptive.currentWindowAdaptiveInfoV2
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
@@ -160,7 +160,7 @@ class InteractiveCellUniverseTests : BaseUiInjectTest(
             with(uiCtx.interactiveCellUniverseCtx) {
                 InteractiveCellUniverse(
                     temporalGameOfLifeState = temporalGameOfLifeState,
-                    windowSizeClass = currentWindowAdaptiveInfo().windowSizeClass,
+                    windowSizeClass = currentWindowAdaptiveInfoV2().windowSizeClass,
                     onSeeMoreSettingsClicked = {},
                     onOpenInSettingsClicked = {},
                     onViewDeserializationInfo = {},
@@ -211,7 +211,7 @@ class InteractiveCellUniverseTests : BaseUiInjectTest(
             with(uiCtx.interactiveCellUniverseCtx) {
                 InteractiveCellUniverse(
                     temporalGameOfLifeState = temporalGameOfLifeState,
-                    windowSizeClass = currentWindowAdaptiveInfo().windowSizeClass,
+                    windowSizeClass = currentWindowAdaptiveInfoV2().windowSizeClass,
                     onSeeMoreSettingsClicked = {},
                     onOpenInSettingsClicked = {},
                     onViewDeserializationInfo = {},
@@ -263,7 +263,7 @@ class InteractiveCellUniverseTests : BaseUiInjectTest(
             with(uiCtx.interactiveCellUniverseCtx) {
                 InteractiveCellUniverse(
                     temporalGameOfLifeState = temporalGameOfLifeState,
-                    windowSizeClass = currentWindowAdaptiveInfo().windowSizeClass,
+                    windowSizeClass = currentWindowAdaptiveInfoV2().windowSizeClass,
                     onSeeMoreSettingsClicked = {},
                     onOpenInSettingsClicked = {},
                     onViewDeserializationInfo = {},
@@ -329,7 +329,7 @@ class InteractiveCellUniverseTests : BaseUiInjectTest(
             with(uiCtx.interactiveCellUniverseCtx) {
                 InteractiveCellUniverse(
                     temporalGameOfLifeState = temporalGameOfLifeState,
-                    windowSizeClass = currentWindowAdaptiveInfo().windowSizeClass,
+                    windowSizeClass = currentWindowAdaptiveInfoV2().windowSizeClass,
                     onSeeMoreSettingsClicked = {},
                     onOpenInSettingsClicked = {},
                     onViewDeserializationInfo = {},
@@ -399,7 +399,7 @@ class InteractiveCellUniverseTests : BaseUiInjectTest(
             with(uiCtx.interactiveCellUniverseCtx) {
                 InteractiveCellUniverse(
                     temporalGameOfLifeState = temporalGameOfLifeState,
-                    windowSizeClass = currentWindowAdaptiveInfo().windowSizeClass,
+                    windowSizeClass = currentWindowAdaptiveInfoV2().windowSizeClass,
                     onSeeMoreSettingsClicked = {},
                     onOpenInSettingsClicked = {},
                     onViewDeserializationInfo = {},
@@ -480,7 +480,7 @@ class InteractiveCellUniverseTests : BaseUiInjectTest(
             with(uiCtx.interactiveCellUniverseCtx) {
                 InteractiveCellUniverse(
                     temporalGameOfLifeState = temporalGameOfLifeState,
-                    windowSizeClass = currentWindowAdaptiveInfo().windowSizeClass,
+                    windowSizeClass = currentWindowAdaptiveInfoV2().windowSizeClass,
                     onSeeMoreSettingsClicked = {},
                     onOpenInSettingsClicked = {},
                     onViewDeserializationInfo = {},
@@ -541,7 +541,7 @@ class InteractiveCellUniverseTests : BaseUiInjectTest(
             with(uiCtx.interactiveCellUniverseCtx) {
                 InteractiveCellUniverse(
                     temporalGameOfLifeState = temporalGameOfLifeState,
-                    windowSizeClass = currentWindowAdaptiveInfo().windowSizeClass,
+                    windowSizeClass = currentWindowAdaptiveInfoV2().windowSizeClass,
                     onSeeMoreSettingsClicked = {},
                     onOpenInSettingsClicked = {},
                     onViewDeserializationInfo = {},
@@ -617,7 +617,7 @@ class InteractiveCellUniverseTests : BaseUiInjectTest(
             with(uiCtx.interactiveCellUniverseCtx) {
                 InteractiveCellUniverse(
                     temporalGameOfLifeState = temporalGameOfLifeState,
-                    windowSizeClass = currentWindowAdaptiveInfo().windowSizeClass,
+                    windowSizeClass = currentWindowAdaptiveInfoV2().windowSizeClass,
                     onSeeMoreSettingsClicked = {},
                     onOpenInSettingsClicked = {},
                     onViewDeserializationInfo = {},
@@ -699,7 +699,7 @@ class InteractiveCellUniverseTests : BaseUiInjectTest(
             with(uiCtx.interactiveCellUniverseCtx) {
                 InteractiveCellUniverse(
                     temporalGameOfLifeState = temporalGameOfLifeState,
-                    windowSizeClass = currentWindowAdaptiveInfo().windowSizeClass,
+                    windowSizeClass = currentWindowAdaptiveInfoV2().windowSizeClass,
                     onSeeMoreSettingsClicked = {},
                     onOpenInSettingsClicked = {},
                     onViewDeserializationInfo = {},
@@ -788,7 +788,7 @@ class InteractiveCellUniverseTests : BaseUiInjectTest(
             with(uiCtx.interactiveCellUniverseCtx) {
                 InteractiveCellUniverse(
                     temporalGameOfLifeState = temporalGameOfLifeState,
-                    windowSizeClass = currentWindowAdaptiveInfo().windowSizeClass,
+                    windowSizeClass = currentWindowAdaptiveInfoV2().windowSizeClass,
                     onSeeMoreSettingsClicked = {},
                     onOpenInSettingsClicked = {},
                     onViewDeserializationInfo = {},
@@ -862,7 +862,7 @@ class InteractiveCellUniverseTests : BaseUiInjectTest(
             with(uiCtx.interactiveCellUniverseCtx) {
                 InteractiveCellUniverse(
                     temporalGameOfLifeState = temporalGameOfLifeState,
-                    windowSizeClass = currentWindowAdaptiveInfo().windowSizeClass,
+                    windowSizeClass = currentWindowAdaptiveInfoV2().windowSizeClass,
                     onSeeMoreSettingsClicked = {},
                     onOpenInSettingsClicked = {},
                     onViewDeserializationInfo = {},

--- a/web-app/src/wasmJsMain/kotlin/com/alexvanyo/composelife/Main.kt
+++ b/web-app/src/wasmJsMain/kotlin/com/alexvanyo/composelife/Main.kt
@@ -16,7 +16,7 @@
 
 package com.alexvanyo.composelife
 
-import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
+import androidx.compose.material3.adaptive.currentWindowAdaptiveInfoV2
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
@@ -119,7 +119,7 @@ fun main() {
                     ComposeLifeTheme(shouldUseDarkTheme()) {
                         with(mainInjectCtx.composeLifeAppUiCtx) {
                             ComposeLifeApp(
-                                windowSizeClass = currentWindowAdaptiveInfo().windowSizeClass,
+                                windowSizeClass = currentWindowAdaptiveInfoV2().windowSizeClass,
                                 windowSize = with(LocalDensity.current) {
                                     LocalWindowInfo.current.containerSize.toSize().toDpSize()
                                 },


### PR DESCRIPTION
Add back allWarningsAsErrors to Kotlin configuration. This was removed in #3259.