### PR TITLE
Fix generateBaselineProfile task missing by checking isDebuggable for JaCoCo

### DIFF
--- a/app/release-badging.txt
+++ b/app/release-badging.txt
@@ -100,7 +100,6 @@ application-icon-480:'res/mipmap-anydpi-v26/ic_launcher.xml'
 application-icon-640:'res/mipmap-anydpi-v26/ic_launcher.xml'
 application-icon-65534:'res/mipmap-anydpi-v26/ic_launcher.xml'
 application: label='ComposeLife' icon='res/mipmap-anydpi-v26/ic_launcher.xml'
-application-debuggable
 uses-library-not-required:'androidx.window.extensions'
 uses-library-not-required:'androidx.window.sidecar'
 uses-library-not-required:'com.android.extensions.xr'

--- a/build-logic/convention/src/main/kotlin/com/alexvanyo/composelife/buildlogic/Jacoco.kt
+++ b/build-logic/convention/src/main/kotlin/com/alexvanyo/composelife/buildlogic/Jacoco.kt
@@ -55,7 +55,11 @@ fun Project.configureJacoco(
 
     commonExtension.buildTypes.configureEach {
         enableUnitTestCoverage = hasUnitTests
-        enableAndroidTestCoverage = hasAndroidTests
+        enableAndroidTestCoverage = if (this is com.android.build.api.dsl.ApplicationBuildType) {
+            isDebuggable && hasAndroidTests
+        } else {
+            hasAndroidTests
+        }
     }
 
     tasks.withType(Test::class.java).configureEach {


### PR DESCRIPTION
This PR fixes the missing `:app:generateBaselineProfile` task.

### Issue
When JaCoCo is applied to `:app` (via the custom `androidApplicationJacoco` plugin), it enables Android test coverage for all build types using `enableAndroidTestCoverage = hasAndroidTests`.
In the Android Gradle Plugin (AGP), setting `enableAndroidTestCoverage = true` on a build type forces the APK to be debuggable (`isDebuggable = true`) because JaCoCo's runtime instrumentation requires debug mode.
However, the `androidx.baselineprofile` plugin filters out any debuggable build types when registering baseline profile tasks. Because all build types in `:app` (including `release` and `staging`) were being forced to be debuggable by JaCoCo, the baseline profile plugin could not find any non-debuggable variants to target. Consequently, the `:app:generateBaselineProfile` task was not generated.

### Solution
In `Jacoco.kt`, only enable Android test coverage for application build types if they are actually debuggable (`isDebuggable`). This keeps the `release` and `staging` build types non-debuggable, allowing `androidx.baselineprofile` to successfully target them and register the baseline profile tasks.