### PR TITLE
Replace "with" calls with "context" for usage with context receivers

### DIFF
--- a/algorithm/src/jbMain/kotlin/com/alexvanyo/composelife/model/TemporalGameOfLifeState.kt
+++ b/algorithm/src/jbMain/kotlin/com/alexvanyo/composelife/model/TemporalGameOfLifeState.kt
@@ -444,12 +444,12 @@ class TemporalGameOfLifeStateMutator(
     private val temporalGameOfLifeState: TemporalGameOfLifeState,
 ) : Updatable {
     override suspend fun update(): Nothing {
-        with(gameOfLifeAlgorithm) {
-            with(dispatchers) {
-                with(clock) {
-                    temporalGameOfLifeState.evolve()
-                }
-            }
+        context(
+            gameOfLifeAlgorithm,
+            dispatchers,
+            clock,
+        ) {
+            temporalGameOfLifeState.evolve()
         }
     }
 }

--- a/app-impl/src/androidMain/kotlin/com/alexvanyo/composelife/MainActivity.kt
+++ b/app-impl/src/androidMain/kotlin/com/alexvanyo/composelife/MainActivity.kt
@@ -138,7 +138,7 @@ class MainActivity : AppCompatActivity() {
             }
 
             ProvideLocalWindowInsetsHolder {
-                with(mainActivityInjectCtx) {
+                context(mainActivityInjectCtx) {
                     val darkTheme = shouldUseDarkTheme()
                     DisposableEffect(darkTheme) {
                         enableEdgeToEdge(
@@ -165,7 +165,7 @@ class MainActivity : AppCompatActivity() {
                     }
 
                     ComposeLifeTheme(darkTheme) {
-                        with(composeLifeAppUiCtx) {
+                        context(mainActivityInjectCtx.composeLifeAppUiCtx) {
                             ComposeLifeApp(
                                 windowSizeClass = currentWindowAdaptiveInfoV2().windowSizeClass,
                                 windowSize = LocalWindowInfo.current.containerDpSize,

--- a/desktop-app/src/desktopMain/kotlin/com/alexvanyo/composelife/Main.kt
+++ b/desktop-app/src/desktopMain/kotlin/com/alexvanyo/composelife/Main.kt
@@ -116,9 +116,9 @@ fun main() = application {
                     }
                 }
 
-                with(mainInjectCtx) {
+                context(mainInjectCtx) {
                     ComposeLifeTheme(shouldUseDarkTheme()) {
-                        with(mainInjectCtx.composeLifeAppUiCtx) {
+                        context(mainInjectCtx.composeLifeAppUiCtx) {
                             ComposeLifeApp(
                                 windowSizeClass = currentWindowAdaptiveInfoV2().windowSizeClass,
                                 windowSize = windowState.size,

--- a/geometry/src/jbTest/kotlin/com/alexvanyo/composelife/geometry/OffsetExtensionsTests.kt
+++ b/geometry/src/jbTest/kotlin/com/alexvanyo/composelife/geometry/OffsetExtensionsTests.kt
@@ -188,7 +188,7 @@ class OffsetExtensionsTests {
     fun to_px_is_correct() {
         val density = Density(density = 2f, fontScale = 1f)
         val dpOffset = DpOffset(10.dp, 20.dp)
-        val offset = with(density) { dpOffset.toPx() }
+        val offset = context(density) { dpOffset.toPx() }
         assertEquals(Offset(20f, 40f), offset)
     }
 

--- a/ui-app-screenshot-tests/src/androidMain/kotlin/com/alexvanyo/composelife/ui/app/CellUniversePanePreviews.kt
+++ b/ui-app-screenshot-tests/src/androidMain/kotlin/com/alexvanyo/composelife/ui/app/CellUniversePanePreviews.kt
@@ -35,7 +35,7 @@ internal fun LoadingCellStateCellUniversePanePreview(modifier: Modifier = Modifi
     WithPreviewDependencies {
         contextOf<PreviewCtx>().testRandom.setSeed(1) // Fix to Beacon loading pattern
         ComposeLifeTheme {
-            with(contextOf<PreviewCtx>().cellUniversePaneCtx) {
+            context(contextOf<PreviewCtx>().cellUniversePaneCtx) {
                 BoxWithConstraints(modifier = modifier) {
                     CellUniversePane(
                         windowSizeClass = BREAKPOINTS_V1.computeWindowSizeClass(
@@ -59,7 +59,7 @@ internal fun LoadingCellStateCellUniversePanePreview(modifier: Modifier = Modifi
 internal fun LoadedCellUniversePanePreview(modifier: Modifier = Modifier) {
     WithPreviewDependencies {
         ComposeLifeTheme {
-            with(contextOf<PreviewCtx>().cellUniversePaneCtx) {
+            context(contextOf<PreviewCtx>().cellUniversePaneCtx) {
                 BoxWithConstraints(modifier = modifier) {
                     val temporalGameOfLifeState = rememberTemporalGameOfLifeState(
                         seedCellState = gosperGliderGun,

--- a/ui-app-screenshot-tests/src/androidMain/kotlin/com/alexvanyo/composelife/ui/app/ComposeLifeAppPreviews.kt
+++ b/ui-app-screenshot-tests/src/androidMain/kotlin/com/alexvanyo/composelife/ui/app/ComposeLifeAppPreviews.kt
@@ -33,7 +33,7 @@ import com.alexvanyo.composelife.ui.util.MobileDevicePreviews
 internal fun LoadingPreferencesComposeLifeAppPreview() {
     WithPreviewDependencies {
         ComposeLifeTheme {
-            with(contextOf<PreviewCtx>().composeLifeAppUiCtx) {
+            context(contextOf<PreviewCtx>().composeLifeAppUiCtx) {
                 BoxWithConstraints {
                     val windowSize = DpSize(maxWidth, maxHeight)
                     ComposeLifeApp(

--- a/ui-app-screenshot-tests/src/androidMain/kotlin/com/alexvanyo/composelife/ui/app/action/ClipboardWatchingSectionPreviews.kt
+++ b/ui-app-screenshot-tests/src/androidMain/kotlin/com/alexvanyo/composelife/ui/app/action/ClipboardWatchingSectionPreviews.kt
@@ -35,7 +35,7 @@ import kotlin.uuid.Uuid
 internal fun ClipboardWatchingSectionOnboardingPreview(modifier: Modifier = Modifier) {
     WithPreviewDependencies {
         ComposeLifeTheme {
-            with(contextOf<PreviewCtx>().clipboardCellStatePreviewCtx) {
+            context(contextOf<PreviewCtx>().clipboardCellStatePreviewCtx) {
                 Surface(modifier) {
                     ClipboardWatchingSection(
                         clipboardWatchingState = object : ClipboardWatchingState.Onboarding {
@@ -55,7 +55,7 @@ internal fun ClipboardWatchingSectionOnboardingPreview(modifier: Modifier = Modi
 private fun ClipboardWatchingSectionDisabledPreview(modifier: Modifier = Modifier) {
     WithPreviewDependencies {
         ComposeLifeTheme {
-            with(contextOf<PreviewCtx>().clipboardCellStatePreviewCtx) {
+            context(contextOf<PreviewCtx>().clipboardCellStatePreviewCtx) {
                 Surface(modifier) {
                     ClipboardWatchingSection(
                         clipboardWatchingState = ClipboardWatchingState.ClipboardWatchingDisabled,
@@ -72,7 +72,7 @@ private fun ClipboardWatchingSectionDisabledPreview(modifier: Modifier = Modifie
 internal fun ClipboardWatchingSectionEnabledLoadingPreview(modifier: Modifier = Modifier) {
     WithPreviewDependencies {
         ComposeLifeTheme {
-            with(contextOf<PreviewCtx>().clipboardCellStatePreviewCtx) {
+            context(contextOf<PreviewCtx>().clipboardCellStatePreviewCtx) {
                 Surface(modifier) {
                     ClipboardWatchingSection(
                         clipboardWatchingState = object : ClipboardWatchingState.ClipboardWatchingEnabled {
@@ -94,7 +94,7 @@ internal fun ClipboardWatchingSectionEnabledLoadingPreview(modifier: Modifier = 
 internal fun ClipboardWatchingSectionEnabledUnsuccessfulPreview(modifier: Modifier = Modifier) {
     WithPreviewDependencies {
         ComposeLifeTheme {
-            with(contextOf<PreviewCtx>().clipboardCellStatePreviewCtx) {
+            context(contextOf<PreviewCtx>().clipboardCellStatePreviewCtx) {
                 Surface(modifier) {
                     ClipboardWatchingSection(
                         clipboardWatchingState = object : ClipboardWatchingState.ClipboardWatchingEnabled {
@@ -130,7 +130,7 @@ internal fun ClipboardWatchingSectionEnabledUnsuccessfulPreview(modifier: Modifi
 internal fun ClipboardWatchingSectionEnabledSuccessfulPreview(modifier: Modifier = Modifier) {
     WithPreviewDependencies {
         ComposeLifeTheme {
-            with(contextOf<PreviewCtx>().clipboardCellStatePreviewCtx) {
+            context(contextOf<PreviewCtx>().clipboardCellStatePreviewCtx) {
                 Surface(modifier) {
                     ClipboardWatchingSection(
                         clipboardWatchingState = object : ClipboardWatchingState.ClipboardWatchingEnabled {

--- a/ui-app-screenshot-tests/src/androidMain/kotlin/com/alexvanyo/composelife/ui/app/action/InlineEditPanePreviews.kt
+++ b/ui-app-screenshot-tests/src/androidMain/kotlin/com/alexvanyo/composelife/ui/app/action/InlineEditPanePreviews.kt
@@ -31,7 +31,7 @@ import com.alexvanyo.composelife.ui.util.ThemePreviews
 internal fun InlineEditPanePreview(modifier: Modifier = Modifier) {
     WithPreviewDependencies {
         ComposeLifeTheme {
-            with(contextOf<PreviewCtx>().inlineEditPaneCtx) {
+            context(contextOf<PreviewCtx>().inlineEditPaneCtx) {
                 Surface(modifier) {
                     InlineEditPane(
                         setSelectionToCellState = {},

--- a/ui-app-screenshot-tests/src/androidMain/kotlin/com/alexvanyo/composelife/ui/app/component/GameOfLifeProgressIndicatorPreviews.kt
+++ b/ui-app-screenshot-tests/src/androidMain/kotlin/com/alexvanyo/composelife/ui/app/component/GameOfLifeProgressIndicatorPreviews.kt
@@ -31,7 +31,7 @@ internal fun GameOfLifeProgressIndicatorBlinkerPreview() {
     WithPreviewDependencies {
         contextOf<PreviewCtx>().testRandom.setSeed(6)
         ComposeLifeTheme {
-            with(contextOf<PreviewCtx>().gameOfLifeProgressIndicatorCtx) {
+            context(contextOf<PreviewCtx>().gameOfLifeProgressIndicatorCtx) {
                 GameOfLifeProgressIndicator()
             }
         }
@@ -45,7 +45,7 @@ internal fun GameOfLifeProgressIndicatorToadPreview() {
     WithPreviewDependencies {
         contextOf<PreviewCtx>().testRandom.setSeed(2)
         ComposeLifeTheme {
-            with(contextOf<PreviewCtx>().gameOfLifeProgressIndicatorCtx) {
+            context(contextOf<PreviewCtx>().gameOfLifeProgressIndicatorCtx) {
                 GameOfLifeProgressIndicator()
             }
         }
@@ -59,7 +59,7 @@ internal fun GameOfLifeProgressIndicatorBeaconPreview() {
     WithPreviewDependencies {
         contextOf<PreviewCtx>().testRandom.setSeed(1)
         ComposeLifeTheme {
-            with(contextOf<PreviewCtx>().gameOfLifeProgressIndicatorCtx) {
+            context(contextOf<PreviewCtx>().gameOfLifeProgressIndicatorCtx) {
                 GameOfLifeProgressIndicator()
             }
         }
@@ -73,7 +73,7 @@ internal fun GameOfLifeProgressIndicatorPulsarPreview() {
     WithPreviewDependencies {
         contextOf<PreviewCtx>().testRandom.setSeed(0)
         ComposeLifeTheme {
-            with(contextOf<PreviewCtx>().gameOfLifeProgressIndicatorCtx) {
+            context(contextOf<PreviewCtx>().gameOfLifeProgressIndicatorCtx) {
                 GameOfLifeProgressIndicator()
             }
         }

--- a/ui-app-screenshot-tests/src/androidMain/kotlin/com/alexvanyo/composelife/ui/app/component/SharedElementPreviews.kt
+++ b/ui-app-screenshot-tests/src/androidMain/kotlin/com/alexvanyo/composelife/ui/app/component/SharedElementPreviews.kt
@@ -243,7 +243,7 @@ private fun CustomAnimatedContentSettingUiSharedElementWithCallerManagedVisibili
 
     WithPreviewDependencies {
         Surface {
-            with(contextOf<PreviewCtx>().settingUiCtx) {
+            context(contextOf<PreviewCtx>().settingUiCtx) {
                 SharedTransitionScope { modifier ->
                     com.alexvanyo.composelife.ui.util.AnimatedContent(
                         TargetState.Single(isExpanded),

--- a/ui-app/src/androidDeviceTest/kotlin/com/alexvanyo/composelife/ui/app/action/LoadedCellStatePreviewTests.kt
+++ b/ui-app/src/androidDeviceTest/kotlin/com/alexvanyo/composelife/ui/app/action/LoadedCellStatePreviewTests.kt
@@ -82,7 +82,7 @@ class LoadedCellStatePreviewTests :
             viewConfiguration = LocalViewConfiguration.current
 
             Column {
-                with(uiCtx.thumbnailImmutableCellWindowCtx) {
+                context(uiCtx.thumbnailImmutableCellWindowCtx) {
                     LoadedCellStatePreview(
                         deserializationResult = DeserializationResult.Successful(
                             cellState = GliderPattern.seedCellState,
@@ -99,7 +99,7 @@ class LoadedCellStatePreviewTests :
                     )
                 }
 
-                with(uiCtx.cellStateParser) {
+                context(uiCtx.cellStateParser) {
                     Spacer(
                         modifier = Modifier
                             .testTag("TestDropTarget")

--- a/ui-app/src/androidSharedTest/kotlin/com/alexvanyo/composelife/ui/app/InteractiveCellUniverseTests.kt
+++ b/ui-app/src/androidSharedTest/kotlin/com/alexvanyo/composelife/ui/app/InteractiveCellUniverseTests.kt
@@ -158,7 +158,7 @@ class InteractiveCellUniverseTests :
                 temporalGameOfLifeStateMutator.update()
             }
 
-            with(uiCtx.interactiveCellUniverseCtx) {
+            context(uiCtx.interactiveCellUniverseCtx) {
                 InteractiveCellUniverse(
                     temporalGameOfLifeState = temporalGameOfLifeState,
                     windowSizeClass = currentWindowAdaptiveInfoV2().windowSizeClass,
@@ -209,7 +209,7 @@ class InteractiveCellUniverseTests :
                 temporalGameOfLifeStateMutator.update()
             }
 
-            with(uiCtx.interactiveCellUniverseCtx) {
+            context(uiCtx.interactiveCellUniverseCtx) {
                 InteractiveCellUniverse(
                     temporalGameOfLifeState = temporalGameOfLifeState,
                     windowSizeClass = currentWindowAdaptiveInfoV2().windowSizeClass,
@@ -261,7 +261,7 @@ class InteractiveCellUniverseTests :
                 temporalGameOfLifeStateMutator.update()
             }
 
-            with(uiCtx.interactiveCellUniverseCtx) {
+            context(uiCtx.interactiveCellUniverseCtx) {
                 InteractiveCellUniverse(
                     temporalGameOfLifeState = temporalGameOfLifeState,
                     windowSizeClass = currentWindowAdaptiveInfoV2().windowSizeClass,
@@ -327,7 +327,7 @@ class InteractiveCellUniverseTests :
                 temporalGameOfLifeStateMutator.update()
             }
 
-            with(uiCtx.interactiveCellUniverseCtx) {
+            context(uiCtx.interactiveCellUniverseCtx) {
                 InteractiveCellUniverse(
                     temporalGameOfLifeState = temporalGameOfLifeState,
                     windowSizeClass = currentWindowAdaptiveInfoV2().windowSizeClass,
@@ -397,7 +397,7 @@ class InteractiveCellUniverseTests :
                 temporalGameOfLifeStateMutator.update()
             }
 
-            with(uiCtx.interactiveCellUniverseCtx) {
+            context(uiCtx.interactiveCellUniverseCtx) {
                 InteractiveCellUniverse(
                     temporalGameOfLifeState = temporalGameOfLifeState,
                     windowSizeClass = currentWindowAdaptiveInfoV2().windowSizeClass,
@@ -478,7 +478,7 @@ class InteractiveCellUniverseTests :
                 temporalGameOfLifeStateMutator.update()
             }
 
-            with(uiCtx.interactiveCellUniverseCtx) {
+            context(uiCtx.interactiveCellUniverseCtx) {
                 InteractiveCellUniverse(
                     temporalGameOfLifeState = temporalGameOfLifeState,
                     windowSizeClass = currentWindowAdaptiveInfoV2().windowSizeClass,
@@ -539,7 +539,7 @@ class InteractiveCellUniverseTests :
             LaunchedEffect(temporalGameOfLifeStateMutator) {
                 temporalGameOfLifeStateMutator.update()
             }
-            with(uiCtx.interactiveCellUniverseCtx) {
+            context(uiCtx.interactiveCellUniverseCtx) {
                 InteractiveCellUniverse(
                     temporalGameOfLifeState = temporalGameOfLifeState,
                     windowSizeClass = currentWindowAdaptiveInfoV2().windowSizeClass,
@@ -615,7 +615,7 @@ class InteractiveCellUniverseTests :
             LaunchedEffect(temporalGameOfLifeStateMutator) {
                 temporalGameOfLifeStateMutator.update()
             }
-            with(uiCtx.interactiveCellUniverseCtx) {
+            context(uiCtx.interactiveCellUniverseCtx) {
                 InteractiveCellUniverse(
                     temporalGameOfLifeState = temporalGameOfLifeState,
                     windowSizeClass = currentWindowAdaptiveInfoV2().windowSizeClass,
@@ -697,7 +697,7 @@ class InteractiveCellUniverseTests :
             LaunchedEffect(temporalGameOfLifeStateMutator) {
                 temporalGameOfLifeStateMutator.update()
             }
-            with(uiCtx.interactiveCellUniverseCtx) {
+            context(uiCtx.interactiveCellUniverseCtx) {
                 InteractiveCellUniverse(
                     temporalGameOfLifeState = temporalGameOfLifeState,
                     windowSizeClass = currentWindowAdaptiveInfoV2().windowSizeClass,
@@ -786,7 +786,7 @@ class InteractiveCellUniverseTests :
                 temporalGameOfLifeStateMutator.update()
             }
 
-            with(uiCtx.interactiveCellUniverseCtx) {
+            context(uiCtx.interactiveCellUniverseCtx) {
                 InteractiveCellUniverse(
                     temporalGameOfLifeState = temporalGameOfLifeState,
                     windowSizeClass = currentWindowAdaptiveInfoV2().windowSizeClass,
@@ -860,7 +860,7 @@ class InteractiveCellUniverseTests :
                 temporalGameOfLifeStateMutator.update()
             }
 
-            with(uiCtx.interactiveCellUniverseCtx) {
+            context(uiCtx.interactiveCellUniverseCtx) {
                 InteractiveCellUniverse(
                     temporalGameOfLifeState = temporalGameOfLifeState,
                     windowSizeClass = currentWindowAdaptiveInfoV2().windowSizeClass,

--- a/ui-cells-screenshot-tests/src/androidMain/kotlin/com/alexvanyo/composelife/ui/cells/CellWindowPreviews.kt
+++ b/ui-cells-screenshot-tests/src/androidMain/kotlin/com/alexvanyo/composelife/ui/cells/CellWindowPreviews.kt
@@ -35,7 +35,7 @@ import kotlin.uuid.Uuid
 internal fun NavigableImmutableCellWindowPreview() {
     WithPreviewDependencies {
         ComposeLifeTheme {
-            with(contextOf<PreviewCtx>().immutableCellWindowCtx) {
+            context(contextOf<PreviewCtx>().immutableCellWindowCtx) {
                 ImmutableCellWindow(
                     gameOfLifeState = remember {
                         GameOfLifeState(
@@ -74,7 +74,7 @@ internal fun NavigableImmutableCellWindowPreview() {
 internal fun TrackingImmutableCellWindowPreview() {
     WithPreviewDependencies {
         ComposeLifeTheme {
-            with(contextOf<PreviewCtx>().immutableCellWindowCtx) {
+            context(contextOf<PreviewCtx>().immutableCellWindowCtx) {
                 val gameOfLifeState = remember {
                     GameOfLifeState(
                         setOf(
@@ -116,7 +116,7 @@ internal fun TrackingImmutableCellWindowPreview() {
 internal fun NavigableMutableCellWindowPreview() {
     WithPreviewDependencies {
         ComposeLifeTheme {
-            with(contextOf<PreviewCtx>().mutableCellWindowCtx) {
+            context(contextOf<PreviewCtx>().mutableCellWindowCtx) {
                 val mutableCellWindowViewportState = rememberMutableCellWindowViewportState()
 
                 val selectionStateHolder = rememberMutableSelectionStateHolder(
@@ -162,7 +162,7 @@ internal fun NavigableMutableCellWindowPreview() {
 internal fun TrackingMutableCellWindowPreview() {
     WithPreviewDependencies {
         ComposeLifeTheme {
-            with(contextOf<PreviewCtx>().mutableCellWindowCtx) {
+            context(contextOf<PreviewCtx>().mutableCellWindowCtx) {
                 val gameOfLifeState = remember {
                     MutableGameOfLifeState(
                         setOf(

--- a/ui-cells-screenshot-tests/src/androidMain/kotlin/com/alexvanyo/composelife/ui/cells/CoilNonInteractableCellsPreviews.kt
+++ b/ui-cells-screenshot-tests/src/androidMain/kotlin/com/alexvanyo/composelife/ui/cells/CoilNonInteractableCellsPreviews.kt
@@ -41,7 +41,7 @@ import com.alexvanyo.composelife.ui.util.ThemePreviews
 internal fun CoilNonInteractableCellsPreview(modifier: Modifier = Modifier) {
     WithPreviewDependencies {
         ComposeLifeTheme {
-            with(contextOf<PreviewCtx>().imageLoader) {
+            context(contextOf<PreviewCtx>().imageLoader) {
                 CoilNonInteractableCells(
                     gameOfLifeState = GameOfLifeState(
                         setOf(

--- a/ui-cells-screenshot-tests/src/androidMain/kotlin/com/alexvanyo/composelife/ui/cells/InteractableCellsPreviews.kt
+++ b/ui-cells-screenshot-tests/src/androidMain/kotlin/com/alexvanyo/composelife/ui/cells/InteractableCellsPreviews.kt
@@ -40,7 +40,7 @@ import com.alexvanyo.composelife.ui.util.ThemePreviews
 internal fun InteractableCellsPreview(modifier: Modifier = Modifier) {
     WithPreviewDependencies {
         ComposeLifeTheme {
-            with(contextOf<PreviewCtx>().interactableCellsCtx) {
+            context(contextOf<PreviewCtx>().interactableCellsCtx) {
                 Box(modifier = modifier.size(300.dp)) {
                     InteractableCells(
                         gameOfLifeState = MutableGameOfLifeState(

--- a/ui-cells-screenshot-tests/src/androidMain/kotlin/com/alexvanyo/composelife/ui/cells/NonInteractableCellsPreviews.kt
+++ b/ui-cells-screenshot-tests/src/androidMain/kotlin/com/alexvanyo/composelife/ui/cells/NonInteractableCellsPreviews.kt
@@ -40,7 +40,7 @@ import com.alexvanyo.composelife.ui.util.ThemePreviews
 internal fun NonInteractableCellsPreview(modifier: Modifier = Modifier) {
     WithPreviewDependencies {
         ComposeLifeTheme {
-            with(contextOf<PreviewCtx>().nonInteractableCellsCtx) {
+            context(contextOf<PreviewCtx>().nonInteractableCellsCtx) {
                 NonInteractableCells(
                     gameOfLifeState = GameOfLifeState(
                         setOf(

--- a/ui-cells/src/jbMain/kotlin/com/alexvanyo/composelife/ui/cells/CellWindowImpl.kt
+++ b/ui-cells/src/jbMain/kotlin/com/alexvanyo/composelife/ui/cells/CellWindowImpl.kt
@@ -330,7 +330,7 @@ private fun CellWindowImpl(
             Box(
                 modifier = navigableModifier,
             ) {
-                with(nonInteractableCellsCtx) {
+                context(nonInteractableCellsCtx) {
                     // Keep the non-interactable cells always visible, to easily be able to switch to it when moving
                     NonInteractableCells(
                         gameOfLifeState = cellWindowUiState.gameOfLifeState,
@@ -349,7 +349,7 @@ private fun CellWindowImpl(
                     )
                 }
 
-                with(interactableCellsCtx) {
+                context(interactableCellsCtx) {
                     // Only show the interactable cells if the conditions are met to be interactable.
                     if (
                         cellWindowUiState.isEditable(
@@ -380,20 +380,21 @@ private fun CellWindowImpl(
                 is CellWindowUiState.ImmutableCellWindowUiState -> Unit
 
                 is CellWindowUiState.MutableState -> {
-                    with(cellWindowImplCtx) {
-                        with(cellStateParser) {
-                            SelectionOverlay(
-                                selectionSessionState =
-                                cellWindowUiState.cellWindowInteractionState.selectionSessionState,
-                                setSelectionSessionState = {
-                                    cellWindowUiState.cellWindowInteractionState.selectionSessionState = it
-                                },
-                                getSelectionCellState = cellWindowUiState::getSelectionCellState,
-                                scaledCellDpSize = scaledCellDpSize,
-                                cellWindow = cellWindow,
-                                pixelOffsetFromCenter = fracPixelOffsetFromCenter,
-                            )
-                        }
+                    context(
+                        cellWindowImplCtx,
+                        cellStateParser,
+                    ) {
+                        SelectionOverlay(
+                            selectionSessionState =
+                            cellWindowUiState.cellWindowInteractionState.selectionSessionState,
+                            setSelectionSessionState = {
+                                cellWindowUiState.cellWindowInteractionState.selectionSessionState = it
+                            },
+                            getSelectionCellState = cellWindowUiState::getSelectionCellState,
+                            scaledCellDpSize = scaledCellDpSize,
+                            cellWindow = cellWindow,
+                            pixelOffsetFromCenter = fracPixelOffsetFromCenter,
+                        )
                     }
                 }
             }

--- a/ui-cells/src/jbTest/kotlin/com/alexvanyo/composelife/ui/cells/InteractableCellsTests.kt
+++ b/ui-cells/src/jbTest/kotlin/com/alexvanyo/composelife/ui/cells/InteractableCellsTests.kt
@@ -238,7 +238,7 @@ class InteractableCellsTests : BaseKmpTest() {
 
         setContent {
             density = LocalDensity.current
-            with(
+            context(
                 InteractableCellsCtx(
                     preferencesHolder = TestComposeLifePreferences(
                         initialPreferences = LoadedComposeLifePreferences.Defaults.copy(
@@ -309,7 +309,7 @@ class InteractableCellsTests : BaseKmpTest() {
 
         setContent {
             density = LocalDensity.current
-            with(
+            context(
                 InteractableCellsCtx(
                     preferencesHolder = TestComposeLifePreferences(
                         initialPreferences = LoadedComposeLifePreferences.Defaults.copy(

--- a/ui-cells/src/jvmTest/kotlin/com/alexvanyo/composelife/ui/cells/SelectionOverlayTests.kt
+++ b/ui-cells/src/jvmTest/kotlin/com/alexvanyo/composelife/ui/cells/SelectionOverlayTests.kt
@@ -76,26 +76,27 @@ class SelectionOverlayTests :
         setContent {
             resolver = parameterizedStringResolver()
 
-            with(ctx.cellWindowImplCtx) {
-                with(ctx.cellStateParser) {
-                    SelectionOverlay(
-                        selectionSessionState = SessionValue(
-                            sessionId = Uuid.random(),
-                            valueId = Uuid.random(),
-                            value = SelectionState.NoSelection,
+            context(
+                ctx.cellWindowImplCtx,
+                ctx.cellStateParser,
+            ) {
+                SelectionOverlay(
+                    selectionSessionState = SessionValue(
+                        sessionId = Uuid.random(),
+                        valueId = Uuid.random(),
+                        value = SelectionState.NoSelection,
+                    ),
+                    setSelectionSessionState = {},
+                    getSelectionCellState = { emptyCellState() },
+                    scaledCellDpSize = 50.dp,
+                    cellWindow = CellWindow(
+                        IntRect(
+                            IntOffset(0, 0),
+                            IntSize(9, 9),
                         ),
-                        setSelectionSessionState = {},
-                        getSelectionCellState = { emptyCellState() },
-                        scaledCellDpSize = 50.dp,
-                        cellWindow = CellWindow(
-                            IntRect(
-                                IntOffset(0, 0),
-                                IntSize(9, 9),
-                            ),
-                        ),
-                        pixelOffsetFromCenter = Offset.Zero,
-                    )
-                }
+                    ),
+                    pixelOffsetFromCenter = Offset.Zero,
+                )
             }
         }
 
@@ -114,31 +115,32 @@ class SelectionOverlayTests :
         setContent {
             resolver = parameterizedStringResolver()
 
-            with(ctx.cellWindowImplCtx) {
-                with(ctx.cellStateParser) {
-                    SelectionOverlay(
-                        selectionSessionState = SessionValue(
-                            sessionId = Uuid.random(),
-                            valueId = Uuid.random(),
-                            value = SelectionState.SelectingBox.FixedSelectingBox(
-                                topLeft = IntOffset(1, 1),
-                                width = 2,
-                                height = 3,
-                                previousTransientSelectingBox = null,
-                            ),
+            context(
+                ctx.cellWindowImplCtx,
+                ctx.cellStateParser,
+            ) {
+                SelectionOverlay(
+                    selectionSessionState = SessionValue(
+                        sessionId = Uuid.random(),
+                        valueId = Uuid.random(),
+                        value = SelectionState.SelectingBox.FixedSelectingBox(
+                            topLeft = IntOffset(1, 1),
+                            width = 2,
+                            height = 3,
+                            previousTransientSelectingBox = null,
                         ),
-                        setSelectionSessionState = {},
-                        getSelectionCellState = { emptyCellState() },
-                        scaledCellDpSize = 50.dp,
-                        cellWindow = CellWindow(
-                            IntRect(
-                                IntOffset(0, 0),
-                                IntSize(9, 9),
-                            ),
+                    ),
+                    setSelectionSessionState = {},
+                    getSelectionCellState = { emptyCellState() },
+                    scaledCellDpSize = 50.dp,
+                    cellWindow = CellWindow(
+                        IntRect(
+                            IntOffset(0, 0),
+                            IntSize(9, 9),
                         ),
-                        pixelOffsetFromCenter = Offset.Zero,
-                    )
-                }
+                    ),
+                    pixelOffsetFromCenter = Offset.Zero,
+                )
             }
         }
 
@@ -188,22 +190,23 @@ class SelectionOverlayTests :
         setContent {
             resolver = parameterizedStringResolver()
 
-            with(ctx.cellWindowImplCtx) {
-                with(ctx.cellStateParser) {
-                    SelectionOverlay(
-                        selectionSessionState = mutableSelectionStateHolder.selectionSessionState,
-                        setSelectionSessionState = { mutableSelectionStateHolder.selectionSessionState = it },
-                        getSelectionCellState = { emptyCellState() },
-                        scaledCellDpSize = 50.dp,
-                        cellWindow = CellWindow(
-                            IntRect(
-                                IntOffset(0, 0),
-                                IntSize(9, 9),
-                            ),
+            context(
+                ctx.cellWindowImplCtx,
+                ctx.cellStateParser,
+            ) {
+                SelectionOverlay(
+                    selectionSessionState = mutableSelectionStateHolder.selectionSessionState,
+                    setSelectionSessionState = { mutableSelectionStateHolder.selectionSessionState = it },
+                    getSelectionCellState = { emptyCellState() },
+                    scaledCellDpSize = 50.dp,
+                    cellWindow = CellWindow(
+                        IntRect(
+                            IntOffset(0, 0),
+                            IntSize(9, 9),
                         ),
-                        pixelOffsetFromCenter = Offset.Zero,
-                    )
-                }
+                    ),
+                    pixelOffsetFromCenter = Offset.Zero,
+                )
             }
         }
 
@@ -232,33 +235,34 @@ class SelectionOverlayTests :
         val ctx = uiGraph.selectionOverlayTestsCtx
 
         setContent {
-            with(ctx.cellWindowImplCtx) {
-                with(ctx.cellStateParser) {
-                    SelectionOverlay(
-                        selectionSessionState = SessionValue(
-                            sessionId = Uuid.random(),
-                            valueId = Uuid.random(),
-                            value = SelectionState.Selection(
-                                cellState = """
+            context(
+                ctx.cellWindowImplCtx,
+                ctx.cellStateParser,
+            ) {
+                SelectionOverlay(
+                    selectionSessionState = SessionValue(
+                        sessionId = Uuid.random(),
+                        valueId = Uuid.random(),
+                        value = SelectionState.Selection(
+                            cellState = """
                                 |.O.
                                 |..O
                                 |OOO
                             """.toCellState(),
-                                offset = IntOffset(1, 1),
-                            ),
+                            offset = IntOffset(1, 1),
                         ),
-                        setSelectionSessionState = {},
-                        getSelectionCellState = { emptyCellState() },
-                        scaledCellDpSize = 50.dp,
-                        cellWindow = CellWindow(
-                            IntRect(
-                                IntOffset(0, 0),
-                                IntSize(9, 9),
-                            ),
+                    ),
+                    setSelectionSessionState = {},
+                    getSelectionCellState = { emptyCellState() },
+                    scaledCellDpSize = 50.dp,
+                    cellWindow = CellWindow(
+                        IntRect(
+                            IntOffset(0, 0),
+                            IntSize(9, 9),
                         ),
-                        pixelOffsetFromCenter = Offset.Zero,
-                    )
-                }
+                    ),
+                    pixelOffsetFromCenter = Offset.Zero,
+                )
             }
         }
 
@@ -288,22 +292,23 @@ class SelectionOverlayTests :
         )
 
         setContent {
-            with(ctx.cellWindowImplCtx) {
-                with(ctx.cellStateParser) {
-                    SelectionOverlay(
-                        selectionSessionState = mutableSelectionStateHolder.selectionSessionState,
-                        setSelectionSessionState = { mutableSelectionStateHolder.selectionSessionState = it },
-                        getSelectionCellState = { emptyCellState() },
-                        scaledCellDpSize = 50.dp,
-                        cellWindow = CellWindow(
-                            IntRect(
-                                IntOffset(0, 0),
-                                IntSize(9, 9),
-                            ),
+            context(
+                ctx.cellWindowImplCtx,
+                ctx.cellStateParser,
+            ) {
+                SelectionOverlay(
+                    selectionSessionState = mutableSelectionStateHolder.selectionSessionState,
+                    setSelectionSessionState = { mutableSelectionStateHolder.selectionSessionState = it },
+                    getSelectionCellState = { emptyCellState() },
+                    scaledCellDpSize = 50.dp,
+                    cellWindow = CellWindow(
+                        IntRect(
+                            IntOffset(0, 0),
+                            IntSize(9, 9),
                         ),
-                        pixelOffsetFromCenter = Offset.Zero,
-                    )
-                }
+                    ),
+                    pixelOffsetFromCenter = Offset.Zero,
+                )
             }
         }
 

--- a/ui-common/src/androidHostTest/kotlin/com/alexvanyo/composelife/ui/util/TimeZoneTests.kt
+++ b/ui-common/src/androidHostTest/kotlin/com/alexvanyo/composelife/ui/util/TimeZoneTests.kt
@@ -55,7 +55,7 @@ class TimeZoneTests :
         var timeZone: TimeZone by mutableStateOf(TimeZone.UTC)
 
         setContent {
-            with(applicationGraph.timeZoneTests.timeZoneHolder) {
+            context(applicationGraph.timeZoneTests.timeZoneHolder) {
                 timeZone = currentTimeZone()
             }
         }

--- a/ui-settings-screenshot-tests/src/androidMain/kotlin/com/alexvanyo/composelife/ui/settings/CellStatePreviewUiPreviews.kt
+++ b/ui-settings-screenshot-tests/src/androidMain/kotlin/com/alexvanyo/composelife/ui/settings/CellStatePreviewUiPreviews.kt
@@ -32,7 +32,7 @@ import com.alexvanyo.composelife.ui.util.ThemePreviews
 internal fun CellStatePreviewUiPreview(modifier: Modifier = Modifier) {
     WithPreviewDependencies {
         ComposeLifeTheme {
-            with(contextOf<PreviewCtx>().cellStatePreviewUiCtx) {
+            context(contextOf<PreviewCtx>().cellStatePreviewUiCtx) {
                 Surface(modifier) {
                     CellStatePreviewUi()
                 }

--- a/ui-settings-screenshot-tests/src/androidMain/kotlin/com/alexvanyo/composelife/ui/settings/FullscreenSettingsPanePreviews.kt
+++ b/ui-settings-screenshot-tests/src/androidMain/kotlin/com/alexvanyo/composelife/ui/settings/FullscreenSettingsPanePreviews.kt
@@ -40,7 +40,7 @@ import com.alexvanyo.composelife.ui.util.MobileDevicePreviews
 internal fun FullscreenSettingsPaneListPreview(modifier: Modifier = Modifier) {
     WithPreviewDependencies {
         ComposeLifeTheme {
-            with(contextOf<PreviewCtx>().fullscreenSettingsDetailPaneCtx) {
+            context(contextOf<PreviewCtx>().fullscreenSettingsDetailPaneCtx) {
                 BoxWithConstraints(modifier) {
                     val windowSizeClass = BREAKPOINTS_V1.computeWindowSizeClass(
                         widthDp = maxWidth.value,
@@ -84,7 +84,7 @@ internal fun FullscreenSettingsPaneListPreview(modifier: Modifier = Modifier) {
 internal fun FullscreenSettingsPaneAlgorithmPreview(modifier: Modifier = Modifier) {
     WithPreviewDependencies {
         ComposeLifeTheme {
-            with(contextOf<PreviewCtx>().fullscreenSettingsDetailPaneCtx) {
+            context(contextOf<PreviewCtx>().fullscreenSettingsDetailPaneCtx) {
                 BoxWithConstraints(modifier) {
                     val windowSizeClass = BREAKPOINTS_V1.computeWindowSizeClass(
                         widthDp = maxWidth.value,
@@ -128,7 +128,7 @@ internal fun FullscreenSettingsPaneAlgorithmPreview(modifier: Modifier = Modifie
 internal fun FullscreenSettingsPaneVisualPreview(modifier: Modifier = Modifier) {
     WithPreviewDependencies {
         ComposeLifeTheme {
-            with(contextOf<PreviewCtx>().fullscreenSettingsDetailPaneCtx) {
+            context(contextOf<PreviewCtx>().fullscreenSettingsDetailPaneCtx) {
                 BoxWithConstraints(modifier) {
                     val windowSizeClass = BREAKPOINTS_V1.computeWindowSizeClass(
                         widthDp = maxWidth.value,
@@ -172,7 +172,7 @@ internal fun FullscreenSettingsPaneVisualPreview(modifier: Modifier = Modifier) 
 internal fun FullscreenSettingsPaneFeatureFlagsPreview(modifier: Modifier = Modifier) {
     WithPreviewDependencies {
         ComposeLifeTheme {
-            with(contextOf<PreviewCtx>().fullscreenSettingsDetailPaneCtx) {
+            context(contextOf<PreviewCtx>().fullscreenSettingsDetailPaneCtx) {
                 BoxWithConstraints(modifier) {
                     val windowSizeClass = BREAKPOINTS_V1.computeWindowSizeClass(
                         widthDp = maxWidth.value,

--- a/ui-settings-screenshot-tests/src/androidMain/kotlin/com/alexvanyo/composelife/ui/settings/InlineSettingsPanePreviews.kt
+++ b/ui-settings-screenshot-tests/src/androidMain/kotlin/com/alexvanyo/composelife/ui/settings/InlineSettingsPanePreviews.kt
@@ -32,7 +32,7 @@ import com.alexvanyo.composelife.ui.util.ThemePreviews
 internal fun InlineSettingsPaneNoQuickAccessPreview(modifier: Modifier = Modifier) {
     WithPreviewDependencies {
         ComposeLifeTheme {
-            with(contextOf<PreviewCtx>().inlineSettingsPaneCtx) {
+            context(contextOf<PreviewCtx>().inlineSettingsPaneCtx) {
                 Surface(modifier) {
                     InlineSettingsPane(
                         onSeeMoreClicked = {},
@@ -54,7 +54,7 @@ internal fun InlineSettingsPaneWithQuickAccessPreview(modifier: Modifier = Modif
             QuickAccessSetting.CellShapeConfig,
         )
         ComposeLifeTheme {
-            with(contextOf<PreviewCtx>().inlineSettingsPaneCtx) {
+            context(contextOf<PreviewCtx>().inlineSettingsPaneCtx) {
                 Surface(modifier) {
                     InlineSettingsPane(
                         onSeeMoreClicked = {},

--- a/ui-settings-screenshot-tests/src/androidMain/kotlin/com/alexvanyo/composelife/ui/settings/PatternCollectionsUiPreviews.kt
+++ b/ui-settings-screenshot-tests/src/androidMain/kotlin/com/alexvanyo/composelife/ui/settings/PatternCollectionsUiPreviews.kt
@@ -35,24 +35,23 @@ import kotlin.time.Instant
 internal fun PatternCollectionPreviewNoSuccessfulSynchronization() {
     val referenceInstant = Instant.fromEpochMilliseconds(1741463473365L)
     WithPreviewDependencies {
-        with(contextOf<PreviewCtx>().timeZoneHolder) {
-            with(
-                object : Clock {
-                    override fun now(): Instant = referenceInstant
-                },
-            ) {
-                PatternCollection(
-                    patternCollection = PatternCollection(
-                        id = PatternCollectionId(0),
-                        sourceUrl = "https://alex.vanyo.dev/composelife/patterns.zip",
-                        lastSuccessfulSynchronizationTimestamp = null,
-                        lastUnsuccessfulSynchronizationTimestamp = null,
-                        synchronizationFailureMessage = null,
-                        isSynchronizing = false,
-                    ),
-                    onDelete = {},
-                )
-            }
+        context(
+            contextOf<PreviewCtx>().timeZoneHolder,
+            object : Clock {
+                override fun now(): Instant = referenceInstant
+            },
+        ) {
+            PatternCollection(
+                patternCollection = PatternCollection(
+                    id = PatternCollectionId(0),
+                    sourceUrl = "https://alex.vanyo.dev/composelife/patterns.zip",
+                    lastSuccessfulSynchronizationTimestamp = null,
+                    lastUnsuccessfulSynchronizationTimestamp = null,
+                    synchronizationFailureMessage = null,
+                    isSynchronizing = false,
+                ),
+                onDelete = {},
+            )
         }
     }
 }
@@ -63,24 +62,23 @@ internal fun PatternCollectionPreviewNoSuccessfulSynchronization() {
 internal fun PatternCollectionPreviewSynchronizing() {
     val referenceInstant = Instant.fromEpochMilliseconds(1741463473365L)
     WithPreviewDependencies {
-        with(contextOf<PreviewCtx>().timeZoneHolder) {
-            with(
-                object : Clock {
-                    override fun now(): Instant = referenceInstant
-                },
-            ) {
-                PatternCollection(
-                    patternCollection = PatternCollection(
-                        id = PatternCollectionId(0),
-                        sourceUrl = "https://alex.vanyo.dev/composelife/patterns.zip",
-                        lastSuccessfulSynchronizationTimestamp = null,
-                        lastUnsuccessfulSynchronizationTimestamp = null,
-                        synchronizationFailureMessage = null,
-                        isSynchronizing = true,
-                    ),
-                    onDelete = {},
-                )
-            }
+        context(
+            contextOf<PreviewCtx>().timeZoneHolder,
+            object : Clock {
+                override fun now(): Instant = referenceInstant
+            },
+        ) {
+            PatternCollection(
+                patternCollection = PatternCollection(
+                    id = PatternCollectionId(0),
+                    sourceUrl = "https://alex.vanyo.dev/composelife/patterns.zip",
+                    lastSuccessfulSynchronizationTimestamp = null,
+                    lastUnsuccessfulSynchronizationTimestamp = null,
+                    synchronizationFailureMessage = null,
+                    isSynchronizing = true,
+                ),
+                onDelete = {},
+            )
         }
     }
 }
@@ -91,24 +89,23 @@ internal fun PatternCollectionPreviewSynchronizing() {
 internal fun PatternCollectionPreviewSuccessfulSynchronizationNow() {
     val referenceInstant = Instant.fromEpochMilliseconds(1741463473365L)
     WithPreviewDependencies {
-        with(contextOf<PreviewCtx>().timeZoneHolder) {
-            with(
-                object : Clock {
-                    override fun now(): Instant = referenceInstant
-                },
-            ) {
-                PatternCollection(
-                    patternCollection = PatternCollection(
-                        id = PatternCollectionId(0),
-                        sourceUrl = "https://alex.vanyo.dev/composelife/patterns.zip",
-                        lastSuccessfulSynchronizationTimestamp = referenceInstant,
-                        lastUnsuccessfulSynchronizationTimestamp = null,
-                        synchronizationFailureMessage = null,
-                        isSynchronizing = false,
-                    ),
-                    onDelete = {},
-                )
-            }
+        context(
+            contextOf<PreviewCtx>().timeZoneHolder,
+            object : Clock {
+                override fun now(): Instant = referenceInstant
+            },
+        ) {
+            PatternCollection(
+                patternCollection = PatternCollection(
+                    id = PatternCollectionId(0),
+                    sourceUrl = "https://alex.vanyo.dev/composelife/patterns.zip",
+                    lastSuccessfulSynchronizationTimestamp = referenceInstant,
+                    lastUnsuccessfulSynchronizationTimestamp = null,
+                    synchronizationFailureMessage = null,
+                    isSynchronizing = false,
+                ),
+                onDelete = {},
+            )
         }
     }
 }
@@ -119,24 +116,23 @@ internal fun PatternCollectionPreviewSuccessfulSynchronizationNow() {
 internal fun PatternCollectionPreviewSuccessfulSynchronization55SecondsAgo() {
     val referenceInstant = Instant.fromEpochMilliseconds(1741463473365L)
     WithPreviewDependencies {
-        with(contextOf<PreviewCtx>().timeZoneHolder) {
-            with(
-                object : Clock {
-                    override fun now(): Instant = referenceInstant
-                },
-            ) {
-                PatternCollection(
-                    patternCollection = PatternCollection(
-                        id = PatternCollectionId(0),
-                        sourceUrl = "https://alex.vanyo.dev/composelife/patterns.zip",
-                        lastSuccessfulSynchronizationTimestamp = referenceInstant - 55.seconds,
-                        lastUnsuccessfulSynchronizationTimestamp = null,
-                        synchronizationFailureMessage = null,
-                        isSynchronizing = false,
-                    ),
-                    onDelete = {},
-                )
-            }
+        context(
+            contextOf<PreviewCtx>().timeZoneHolder,
+            object : Clock {
+                override fun now(): Instant = referenceInstant
+            },
+        ) {
+            PatternCollection(
+                patternCollection = PatternCollection(
+                    id = PatternCollectionId(0),
+                    sourceUrl = "https://alex.vanyo.dev/composelife/patterns.zip",
+                    lastSuccessfulSynchronizationTimestamp = referenceInstant - 55.seconds,
+                    lastUnsuccessfulSynchronizationTimestamp = null,
+                    synchronizationFailureMessage = null,
+                    isSynchronizing = false,
+                ),
+                onDelete = {},
+            )
         }
     }
 }
@@ -147,24 +143,23 @@ internal fun PatternCollectionPreviewSuccessfulSynchronization55SecondsAgo() {
 internal fun PatternCollectionPreviewSuccessfulSynchronization60SecondsAgo() {
     val referenceInstant = Instant.fromEpochMilliseconds(1741463473365L)
     WithPreviewDependencies {
-        with(contextOf<PreviewCtx>().timeZoneHolder) {
-            with(
-                object : Clock {
-                    override fun now(): Instant = referenceInstant
-                },
-            ) {
-                PatternCollection(
-                    patternCollection = PatternCollection(
-                        id = PatternCollectionId(0),
-                        sourceUrl = "https://alex.vanyo.dev/composelife/patterns.zip",
-                        lastSuccessfulSynchronizationTimestamp = referenceInstant - 60.seconds,
-                        lastUnsuccessfulSynchronizationTimestamp = null,
-                        synchronizationFailureMessage = null,
-                        isSynchronizing = false,
-                    ),
-                    onDelete = {},
-                )
-            }
+        context(
+            contextOf<PreviewCtx>().timeZoneHolder,
+            object : Clock {
+                override fun now(): Instant = referenceInstant
+            },
+        ) {
+            PatternCollection(
+                patternCollection = PatternCollection(
+                    id = PatternCollectionId(0),
+                    sourceUrl = "https://alex.vanyo.dev/composelife/patterns.zip",
+                    lastSuccessfulSynchronizationTimestamp = referenceInstant - 60.seconds,
+                    lastUnsuccessfulSynchronizationTimestamp = null,
+                    synchronizationFailureMessage = null,
+                    isSynchronizing = false,
+                ),
+                onDelete = {},
+            )
         }
     }
 }
@@ -175,24 +170,23 @@ internal fun PatternCollectionPreviewSuccessfulSynchronization60SecondsAgo() {
 internal fun PatternCollectionPreviewSuccessfulSynchronization65SecondsAgo() {
     val referenceInstant = Instant.fromEpochMilliseconds(1741463473365L)
     WithPreviewDependencies {
-        with(contextOf<PreviewCtx>().timeZoneHolder) {
-            with(
-                object : Clock {
-                    override fun now(): Instant = referenceInstant
-                },
-            ) {
-                PatternCollection(
-                    patternCollection = PatternCollection(
-                        id = PatternCollectionId(0),
-                        sourceUrl = "https://alex.vanyo.dev/composelife/patterns.zip",
-                        lastSuccessfulSynchronizationTimestamp = referenceInstant - 65.seconds,
-                        lastUnsuccessfulSynchronizationTimestamp = null,
-                        synchronizationFailureMessage = null,
-                        isSynchronizing = false,
-                    ),
-                    onDelete = {},
-                )
-            }
+        context(
+            contextOf<PreviewCtx>().timeZoneHolder,
+            object : Clock {
+                override fun now(): Instant = referenceInstant
+            },
+        ) {
+            PatternCollection(
+                patternCollection = PatternCollection(
+                    id = PatternCollectionId(0),
+                    sourceUrl = "https://alex.vanyo.dev/composelife/patterns.zip",
+                    lastSuccessfulSynchronizationTimestamp = referenceInstant - 65.seconds,
+                    lastUnsuccessfulSynchronizationTimestamp = null,
+                    synchronizationFailureMessage = null,
+                    isSynchronizing = false,
+                ),
+                onDelete = {},
+            )
         }
     }
 }
@@ -203,24 +197,23 @@ internal fun PatternCollectionPreviewSuccessfulSynchronization65SecondsAgo() {
 internal fun PatternCollectionPreviewSuccessfulSynchronization65MinutesAgo() {
     val referenceInstant = Instant.fromEpochMilliseconds(1741463473365L)
     WithPreviewDependencies {
-        with(contextOf<PreviewCtx>().timeZoneHolder) {
-            with(
-                object : Clock {
-                    override fun now(): Instant = referenceInstant
-                },
-            ) {
-                PatternCollection(
-                    patternCollection = PatternCollection(
-                        id = PatternCollectionId(0),
-                        sourceUrl = "https://alex.vanyo.dev/composelife/patterns.zip",
-                        lastSuccessfulSynchronizationTimestamp = referenceInstant - 65.minutes,
-                        lastUnsuccessfulSynchronizationTimestamp = null,
-                        synchronizationFailureMessage = null,
-                        isSynchronizing = false,
-                    ),
-                    onDelete = {},
-                )
-            }
+        context(
+            contextOf<PreviewCtx>().timeZoneHolder,
+            object : Clock {
+                override fun now(): Instant = referenceInstant
+            },
+        ) {
+            PatternCollection(
+                patternCollection = PatternCollection(
+                    id = PatternCollectionId(0),
+                    sourceUrl = "https://alex.vanyo.dev/composelife/patterns.zip",
+                    lastSuccessfulSynchronizationTimestamp = referenceInstant - 65.minutes,
+                    lastUnsuccessfulSynchronizationTimestamp = null,
+                    synchronizationFailureMessage = null,
+                    isSynchronizing = false,
+                ),
+                onDelete = {},
+            )
         }
     }
 }
@@ -231,24 +224,23 @@ internal fun PatternCollectionPreviewSuccessfulSynchronization65MinutesAgo() {
 internal fun PatternCollectionPreviewSuccessfulSynchronization25HoursAgo() {
     val referenceInstant = Instant.fromEpochMilliseconds(1741463473365L)
     WithPreviewDependencies {
-        with(contextOf<PreviewCtx>().timeZoneHolder) {
-            with(
-                object : Clock {
-                    override fun now(): Instant = referenceInstant
-                },
-            ) {
-                PatternCollection(
-                    patternCollection = PatternCollection(
-                        id = PatternCollectionId(0),
-                        sourceUrl = "https://alex.vanyo.dev/composelife/patterns.zip",
-                        lastSuccessfulSynchronizationTimestamp = referenceInstant - 25.hours,
-                        lastUnsuccessfulSynchronizationTimestamp = null,
-                        synchronizationFailureMessage = null,
-                        isSynchronizing = false,
-                    ),
-                    onDelete = {},
-                )
-            }
+        context(
+            contextOf<PreviewCtx>().timeZoneHolder,
+            object : Clock {
+                override fun now(): Instant = referenceInstant
+            },
+        ) {
+            PatternCollection(
+                patternCollection = PatternCollection(
+                    id = PatternCollectionId(0),
+                    sourceUrl = "https://alex.vanyo.dev/composelife/patterns.zip",
+                    lastSuccessfulSynchronizationTimestamp = referenceInstant - 25.hours,
+                    lastUnsuccessfulSynchronizationTimestamp = null,
+                    synchronizationFailureMessage = null,
+                    isSynchronizing = false,
+                ),
+                onDelete = {},
+            )
         }
     }
 }

--- a/ui-settings/src/androidHostTest/kotlin/com/alexvanyo/composelife/ui/settings/FullscreenSettingsPaneRobolectricTests.kt
+++ b/ui-settings/src/androidHostTest/kotlin/com/alexvanyo/composelife/ui/settings/FullscreenSettingsPaneRobolectricTests.kt
@@ -104,7 +104,7 @@ class FullscreenSettingsPaneRobolectricTests :
                     heightDp = maxHeight.value,
                 )
 
-                with(ctx.fullscreenSettingsDetailPaneCtx) {
+                context(ctx.fullscreenSettingsDetailPaneCtx) {
                     FullscreenSettingsPane(
                         fullscreenSettingsListPaneState = object : FullscreenSettingsListPaneState {
                             override val settingsCategory = settingsCategory
@@ -193,7 +193,7 @@ class FullscreenSettingsPaneRobolectricTests :
                     heightDp = maxHeight.value,
                 )
 
-                with(ctx.fullscreenSettingsDetailPaneCtx) {
+                context(ctx.fullscreenSettingsDetailPaneCtx) {
                     FullscreenSettingsPane(
                         fullscreenSettingsListPaneState = object : FullscreenSettingsListPaneState {
                             override val settingsCategory = settingsCategory
@@ -286,7 +286,7 @@ class FullscreenSettingsPaneRobolectricTests :
                     heightDp = maxHeight.value,
                 )
 
-                with(ctx.fullscreenSettingsDetailPaneCtx) {
+                context(ctx.fullscreenSettingsDetailPaneCtx) {
                     FullscreenSettingsPane(
                         fullscreenSettingsListPaneState = object : FullscreenSettingsListPaneState {
                             override val settingsCategory = settingsCategory
@@ -363,7 +363,7 @@ class FullscreenSettingsPaneRobolectricTests :
                     heightDp = maxHeight.value,
                 )
 
-                with(ctx.fullscreenSettingsDetailPaneCtx) {
+                context(ctx.fullscreenSettingsDetailPaneCtx) {
                     FullscreenSettingsPane(
                         fullscreenSettingsListPaneState = object : FullscreenSettingsListPaneState {
                             override val settingsCategory = settingsCategory
@@ -448,7 +448,7 @@ class FullscreenSettingsPaneRobolectricTests :
                     heightDp = maxHeight.value,
                 )
 
-                with(ctx.fullscreenSettingsDetailPaneCtx) {
+                context(ctx.fullscreenSettingsDetailPaneCtx) {
                     FullscreenSettingsPane(
                         fullscreenSettingsListPaneState = object : FullscreenSettingsListPaneState {
                             override val settingsCategory = settingsCategory
@@ -519,7 +519,7 @@ class FullscreenSettingsPaneRobolectricTests :
                     heightDp = maxHeight.value,
                 )
 
-                with(ctx.fullscreenSettingsDetailPaneCtx) {
+                context(ctx.fullscreenSettingsDetailPaneCtx) {
                     FullscreenSettingsPane(
                         fullscreenSettingsListPaneState = object : FullscreenSettingsListPaneState {
                             override val settingsCategory = settingsCategory
@@ -597,7 +597,7 @@ class FullscreenSettingsPaneRobolectricTests :
 
         setContent {
             resolver = parameterizedStringResolver()
-            with(ctx.fullscreenSettingsDetailPaneCtx) {
+            context(ctx.fullscreenSettingsDetailPaneCtx) {
                 FullscreenSettingsPane(
                     fullscreenSettingsListPaneState = object : FullscreenSettingsListPaneState {
                         override val settingsCategory = settingsCategory
@@ -651,7 +651,7 @@ class FullscreenSettingsPaneRobolectricTests :
 
         setContent {
             resolver = parameterizedStringResolver()
-            with(ctx.fullscreenSettingsDetailPaneCtx) {
+            context(ctx.fullscreenSettingsDetailPaneCtx) {
                 FullscreenSettingsPane(
                     fullscreenSettingsListPaneState = object : FullscreenSettingsListPaneState {
                         override val settingsCategory = settingsCategory
@@ -716,7 +716,7 @@ class FullscreenSettingsPaneRobolectricTests :
                     heightDp = maxHeight.value,
                 )
 
-                with(ctx.fullscreenSettingsDetailPaneCtx) {
+                context(ctx.fullscreenSettingsDetailPaneCtx) {
                     FullscreenSettingsPane(
                         fullscreenSettingsListPaneState = object : FullscreenSettingsListPaneState {
                             override val settingsCategory = settingsCategory
@@ -788,7 +788,7 @@ class FullscreenSettingsPaneRobolectricTests :
                     heightDp = maxHeight.value,
                 )
 
-                with(ctx.fullscreenSettingsDetailPaneCtx) {
+                context(ctx.fullscreenSettingsDetailPaneCtx) {
                     FullscreenSettingsPane(
                         fullscreenSettingsListPaneState = object : FullscreenSettingsListPaneState {
                             override val settingsCategory = settingsCategory

--- a/ui-settings/src/androidSharedTest/kotlin/com/alexvanyo/composelife/ui/settings/FullscreenSettingsDetailPaneTests.kt
+++ b/ui-settings/src/androidSharedTest/kotlin/com/alexvanyo/composelife/ui/settings/FullscreenSettingsDetailPaneTests.kt
@@ -80,7 +80,7 @@ class FullscreenSettingsDetailPaneTests :
 
         setContent {
             resolver = parameterizedStringResolver()
-            with(ctx.fullscreenSettingsDetailPaneCtx) {
+            context(ctx.fullscreenSettingsDetailPaneCtx) {
                 DeviceConfigurationOverride(
                     DeviceConfigurationOverride.ForcedSize(DpSize(400.dp, 1200.dp)),
                 ) {

--- a/ui-settings/src/androidSharedTest/kotlin/com/alexvanyo/composelife/ui/settings/FullscreenSettingsPaneTests.kt
+++ b/ui-settings/src/androidSharedTest/kotlin/com/alexvanyo/composelife/ui/settings/FullscreenSettingsPaneTests.kt
@@ -104,7 +104,7 @@ class FullscreenSettingsPaneTests :
                         heightDp = maxHeight.value,
                     )
 
-                    with(ctx.fullscreenSettingsDetailPaneCtx) {
+                    context(ctx.fullscreenSettingsDetailPaneCtx) {
                         FullscreenSettingsPane(
                             fullscreenSettingsListPaneState = object : FullscreenSettingsListPaneState {
                                 override val settingsCategory = settingsCategory
@@ -196,7 +196,7 @@ class FullscreenSettingsPaneTests :
                         heightDp = maxHeight.value,
                     )
 
-                    with(ctx.fullscreenSettingsDetailPaneCtx) {
+                    context(ctx.fullscreenSettingsDetailPaneCtx) {
                         FullscreenSettingsPane(
                             fullscreenSettingsListPaneState = object : FullscreenSettingsListPaneState {
                                 override val settingsCategory = settingsCategory
@@ -292,7 +292,7 @@ class FullscreenSettingsPaneTests :
                         heightDp = maxHeight.value,
                     )
 
-                    with(ctx.fullscreenSettingsDetailPaneCtx) {
+                    context(ctx.fullscreenSettingsDetailPaneCtx) {
                         FullscreenSettingsPane(
                             fullscreenSettingsListPaneState = object : FullscreenSettingsListPaneState {
                                 override val settingsCategory = settingsCategory
@@ -372,7 +372,7 @@ class FullscreenSettingsPaneTests :
                         heightDp = maxHeight.value,
                     )
 
-                    with(ctx.fullscreenSettingsDetailPaneCtx) {
+                    context(ctx.fullscreenSettingsDetailPaneCtx) {
                         FullscreenSettingsPane(
                             fullscreenSettingsListPaneState = object : FullscreenSettingsListPaneState {
                                 override val settingsCategory = settingsCategory
@@ -460,7 +460,7 @@ class FullscreenSettingsPaneTests :
                         heightDp = maxHeight.value,
                     )
 
-                    with(ctx.fullscreenSettingsDetailPaneCtx) {
+                    context(ctx.fullscreenSettingsDetailPaneCtx) {
                         FullscreenSettingsPane(
                             fullscreenSettingsListPaneState = object : FullscreenSettingsListPaneState {
                                 override val settingsCategory = settingsCategory
@@ -534,7 +534,7 @@ class FullscreenSettingsPaneTests :
                         heightDp = maxHeight.value,
                     )
 
-                    with(ctx.fullscreenSettingsDetailPaneCtx) {
+                    context(ctx.fullscreenSettingsDetailPaneCtx) {
                         FullscreenSettingsPane(
                             fullscreenSettingsListPaneState = object : FullscreenSettingsListPaneState {
                                 override val settingsCategory = settingsCategory
@@ -615,7 +615,7 @@ class FullscreenSettingsPaneTests :
             DeviceConfigurationOverride(
                 DeviceConfigurationOverride.ForcedSize(DpSize(300.dp, 300.dp)),
             ) {
-                with(ctx.fullscreenSettingsDetailPaneCtx) {
+                context(ctx.fullscreenSettingsDetailPaneCtx) {
                     FullscreenSettingsPane(
                         fullscreenSettingsListPaneState = object : FullscreenSettingsListPaneState {
                             override val settingsCategory = settingsCategory
@@ -672,7 +672,7 @@ class FullscreenSettingsPaneTests :
             DeviceConfigurationOverride(
                 DeviceConfigurationOverride.ForcedSize(DpSize(300.dp, 300.dp)),
             ) {
-                with(ctx.fullscreenSettingsDetailPaneCtx) {
+                context(ctx.fullscreenSettingsDetailPaneCtx) {
                     FullscreenSettingsPane(
                         fullscreenSettingsListPaneState = object : FullscreenSettingsListPaneState {
                             override val settingsCategory = settingsCategory
@@ -740,7 +740,7 @@ class FullscreenSettingsPaneTests :
                         heightDp = maxHeight.value,
                     )
 
-                    with(ctx.fullscreenSettingsDetailPaneCtx) {
+                    context(ctx.fullscreenSettingsDetailPaneCtx) {
                         FullscreenSettingsPane(
                             fullscreenSettingsListPaneState = object : FullscreenSettingsListPaneState {
                                 override val settingsCategory = settingsCategory
@@ -812,7 +812,7 @@ class FullscreenSettingsPaneTests :
                         heightDp = maxHeight.value,
                     )
 
-                    with(ctx.fullscreenSettingsDetailPaneCtx) {
+                    context(ctx.fullscreenSettingsDetailPaneCtx) {
                         FullscreenSettingsPane(
                             fullscreenSettingsListPaneState = object : FullscreenSettingsListPaneState {
                                 override val settingsCategory = settingsCategory

--- a/ui-settings/src/jbTest/kotlin/com/alexvanyo/composelife/ui/settings/CellShapeConfigUiTests.kt
+++ b/ui-settings/src/jbTest/kotlin/com/alexvanyo/composelife/ui/settings/CellShapeConfigUiTests.kt
@@ -77,7 +77,7 @@ class CellShapeConfigUiTests : BaseKmpTest() {
             setContent {
                 resolver = parameterizedStringResolver()
 
-                val cellShapeConfigUiState = with(
+                val cellShapeConfigUiState = context(
                     CellShapeConfigUiCtx(
                         preferencesHolder = composeLifePreferences,
                         composeLifePreferences = composeLifePreferences,
@@ -135,7 +135,7 @@ class CellShapeConfigUiTests : BaseKmpTest() {
             setContent {
                 resolver = parameterizedStringResolver()
 
-                val cellShapeConfigUiState = with(
+                val cellShapeConfigUiState = context(
                     CellShapeConfigUiCtx(
                         preferencesHolder = composeLifePreferences,
                         composeLifePreferences = composeLifePreferences,
@@ -179,7 +179,7 @@ class CellShapeConfigUiTests : BaseKmpTest() {
             setContent {
                 resolver = parameterizedStringResolver()
 
-                val cellShapeConfigUiState = with(
+                val cellShapeConfigUiState = context(
                     CellShapeConfigUiCtx(
                         preferencesHolder = composeLifePreferences,
                         composeLifePreferences = composeLifePreferences,
@@ -223,7 +223,7 @@ class CellShapeConfigUiTests : BaseKmpTest() {
             setContent {
                 resolver = parameterizedStringResolver()
 
-                val cellShapeConfigUiState = with(
+                val cellShapeConfigUiState = context(
                     CellShapeConfigUiCtx(
                         preferencesHolder = composeLifePreferences,
                         composeLifePreferences = composeLifePreferences,

--- a/ui-settings/src/jbTest/kotlin/com/alexvanyo/composelife/ui/settings/PatternCollectionsUiTests.kt
+++ b/ui-settings/src/jbTest/kotlin/com/alexvanyo/composelife/ui/settings/PatternCollectionsUiTests.kt
@@ -59,14 +59,15 @@ class PatternCollectionsUiTests : BaseKmpTest() {
 
             setContent {
                 resolver = parameterizedStringResolver()
-                with(testClock) {
-                    with(testTimeZoneHolder) {
-                        PatternCollectionsUi(
-                            patternCollectionsState = ResourceState.Success(emptyList()),
-                            addPatternCollection = {},
-                            deletePatternCollection = {},
-                        )
-                    }
+                context(
+                    testClock,
+                    testTimeZoneHolder,
+                ) {
+                    PatternCollectionsUi(
+                        patternCollectionsState = ResourceState.Success(emptyList()),
+                        addPatternCollection = {},
+                        deletePatternCollection = {},
+                    )
                 }
             }
 
@@ -82,14 +83,15 @@ class PatternCollectionsUiTests : BaseKmpTest() {
 
             setContent {
                 resolver = parameterizedStringResolver()
-                with(testClock) {
-                    with(testTimeZoneHolder) {
-                        PatternCollectionsUi(
-                            patternCollectionsState = ResourceState.Success(emptyList()),
-                            addPatternCollection = {},
-                            deletePatternCollection = {},
-                        )
-                    }
+                context(
+                    testClock,
+                    testTimeZoneHolder,
+                ) {
+                    PatternCollectionsUi(
+                        patternCollectionsState = ResourceState.Success(emptyList()),
+                        addPatternCollection = {},
+                        deletePatternCollection = {},
+                    )
                 }
             }
 
@@ -108,14 +110,15 @@ class PatternCollectionsUiTests : BaseKmpTest() {
 
             setContent {
                 resolver = parameterizedStringResolver()
-                with(testClock) {
-                    with(testTimeZoneHolder) {
-                        PatternCollectionsUi(
-                            patternCollectionsState = ResourceState.Success(emptyList()),
-                            addPatternCollection = {},
-                            deletePatternCollection = {},
-                        )
-                    }
+                context(
+                    testClock,
+                    testTimeZoneHolder,
+                ) {
+                    PatternCollectionsUi(
+                        patternCollectionsState = ResourceState.Success(emptyList()),
+                        addPatternCollection = {},
+                        deletePatternCollection = {},
+                    )
                 }
             }
 
@@ -143,14 +146,15 @@ class PatternCollectionsUiTests : BaseKmpTest() {
 
             setContent {
                 resolver = parameterizedStringResolver()
-                with(testClock) {
-                    with(testTimeZoneHolder) {
-                        PatternCollectionsUi(
-                            patternCollectionsState = ResourceState.Success(listOf(patternCollection)),
-                            addPatternCollection = {},
-                            deletePatternCollection = {},
-                        )
-                    }
+                context(
+                    testClock,
+                    testTimeZoneHolder,
+                ) {
+                    PatternCollectionsUi(
+                        patternCollectionsState = ResourceState.Success(listOf(patternCollection)),
+                        addPatternCollection = {},
+                        deletePatternCollection = {},
+                    )
                 }
             }
 
@@ -178,14 +182,15 @@ class PatternCollectionsUiTests : BaseKmpTest() {
 
             setContent {
                 resolver = parameterizedStringResolver()
-                with(testClock) {
-                    with(testTimeZoneHolder) {
-                        PatternCollectionsUi(
-                            patternCollectionsState = ResourceState.Success(listOf(patternCollection)),
-                            addPatternCollection = {},
-                            deletePatternCollection = { deletedId = it },
-                        )
-                    }
+                context(
+                    testClock,
+                    testTimeZoneHolder,
+                ) {
+                    PatternCollectionsUi(
+                        patternCollectionsState = ResourceState.Success(listOf(patternCollection)),
+                        addPatternCollection = {},
+                        deletePatternCollection = { deletedId = it },
+                    )
                 }
             }
 
@@ -205,14 +210,15 @@ class PatternCollectionsUiTests : BaseKmpTest() {
 
             setContent {
                 resolver = parameterizedStringResolver()
-                with(testClock) {
-                    with(testTimeZoneHolder) {
-                        PatternCollectionsUi(
-                            patternCollectionsState = ResourceState.Success(emptyList()),
-                            addPatternCollection = { addedUrl = it },
-                            deletePatternCollection = {},
-                        )
-                    }
+                context(
+                    testClock,
+                    testTimeZoneHolder,
+                ) {
+                    PatternCollectionsUi(
+                        patternCollectionsState = ResourceState.Success(emptyList()),
+                        addPatternCollection = { addedUrl = it },
+                        deletePatternCollection = {},
+                    )
                 }
             }
 

--- a/ui-settings/src/jvmTest/kotlin/com/alexvanyo/composelife/ui/settings/InlineSettingsPaneTests.kt
+++ b/ui-settings/src/jvmTest/kotlin/com/alexvanyo/composelife/ui/settings/InlineSettingsPaneTests.kt
@@ -77,7 +77,7 @@ class InlineSettingsPaneTests :
 
             setContent {
                 resolver = parameterizedStringResolver()
-                with(ctx.inlineSettingsPaneCtx) {
+                context(ctx.inlineSettingsPaneCtx) {
                     InlineSettingsPane(
                         onSeeMoreClicked = {
                             onSeeMoreClickedCount++
@@ -112,7 +112,7 @@ class InlineSettingsPaneTests :
 
             setContent {
                 resolver = parameterizedStringResolver()
-                with(ctx.inlineSettingsPaneCtx) {
+                context(ctx.inlineSettingsPaneCtx) {
                     InlineSettingsPane(
                         onSeeMoreClicked = {},
                         onOpenInSettingsClicked = {},
@@ -159,7 +159,7 @@ class InlineSettingsPaneTests :
 
             setContent {
                 resolver = parameterizedStringResolver()
-                with(ctx.inlineSettingsPaneCtx) {
+                context(ctx.inlineSettingsPaneCtx) {
                     InlineSettingsPane(
                         onSeeMoreClicked = {},
                         onOpenInSettingsClicked = {
@@ -193,7 +193,7 @@ class InlineSettingsPaneTests :
 
             setContent {
                 resolver = parameterizedStringResolver()
-                with(ctx.inlineSettingsPaneCtx) {
+                context(ctx.inlineSettingsPaneCtx) {
                     InlineSettingsPane(
                         onSeeMoreClicked = {},
                         onOpenInSettingsClicked = {},

--- a/wear-watchface/src/androidMain/kotlin/com/alexvanyo/composelife/wear/watchface/GameOfLifeWatchFaceService.kt
+++ b/wear-watchface/src/androidMain/kotlin/com/alexvanyo/composelife/wear/watchface/GameOfLifeWatchFaceService.kt
@@ -91,12 +91,12 @@ class GameOfLifeWatchFaceService : WatchFaceService() {
         dispatchers = ctx.dispatchers
 
         scope.launch {
-            with(gameOfLifeAlgorithm) {
-                with(dispatchers) {
-                    with(Clock.System) {
-                        temporalGameOfLifeState.evolve()
-                    }
-                }
+            context(
+                gameOfLifeAlgorithm,
+                dispatchers,
+                Clock.System,
+            ) {
+                temporalGameOfLifeState.evolve()
             }
         }
     }

--- a/web-app/src/wasmJsMain/kotlin/com/alexvanyo/composelife/Main.kt
+++ b/web-app/src/wasmJsMain/kotlin/com/alexvanyo/composelife/Main.kt
@@ -115,9 +115,9 @@ fun main() {
                     }
                 }
 
-                with(mainInjectCtx) {
+                context(mainInjectCtx) {
                     ComposeLifeTheme(shouldUseDarkTheme()) {
-                        with(mainInjectCtx.composeLifeAppUiCtx) {
+                        context(mainInjectCtx.composeLifeAppUiCtx) {
                             ComposeLifeApp(
                                 windowSizeClass = currentWindowAdaptiveInfoV2().windowSizeClass,
                                 windowSize = with(LocalDensity.current) {


### PR DESCRIPTION
All usages of `with` throughout the project that are only used to put something as a context receiver have been migrated to use `context` instead.

Fixes #3439