### PR TITLE
Fix dependency indentation in build.gradle.kts files

### DIFF
--- a/algorithm-benchmark/build.gradle.kts
+++ b/algorithm-benchmark/build.gradle.kts
@@ -49,17 +49,17 @@ android {
 //}
 
 dependencies {
- implementation(libs.androidx.benchmark.micro.junit4)
- implementation(libs.androidx.test.runner)
- implementation(libs.androidx.tracing)
- implementation(projects.algorithm)
+    implementation(libs.androidx.benchmark.micro.junit4)
+    implementation(libs.androidx.test.runner)
+    implementation(libs.androidx.tracing)
+    implementation(projects.algorithm)
 
- androidTestImplementation(libs.androidx.test.junit)
- androidTestImplementation(libs.junit4)
- androidTestImplementation(libs.kotlin.test.junit)
- androidTestImplementation(libs.testParameterInjector.junit4)
- androidTestImplementation(projects.dispatchersTestFixtures)
- androidTestImplementation(projects.patterns)
- androidTestImplementation(projects.tracingTestFixtures)
+    androidTestImplementation(libs.androidx.test.junit)
+    androidTestImplementation(libs.junit4)
+    androidTestImplementation(libs.kotlin.test.junit)
+    androidTestImplementation(libs.testParameterInjector.junit4)
+    androidTestImplementation(projects.dispatchersTestFixtures)
+    androidTestImplementation(projects.patterns)
+    androidTestImplementation(projects.tracingTestFixtures)
 }
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -55,15 +55,15 @@ baselineProfile {
 }
 
 dependencies {
- implementation(projects.appImpl)
+    implementation(projects.appImpl)
 
- stagingImplementation(libs.leakCanary.android)
+    stagingImplementation(libs.leakCanary.android)
 
- debugImplementation(libs.leakCanary.android)
+    debugImplementation(libs.leakCanary.android)
 
- androidTestImplementation(projects.appTestFixtures)
+    androidTestImplementation(projects.appTestFixtures)
 
- baselineProfile(projects.appBaselineProfileGenerator)
+    baselineProfile(projects.appBaselineProfileGenerator)
 }
 
 dependencyGuard {

--- a/wear/build.gradle.kts
+++ b/wear/build.gradle.kts
@@ -52,13 +52,13 @@ baselineProfile {
 }
 
 dependencies {
- implementation(projects.wearImpl)
+    implementation(projects.wearImpl)
 
- stagingImplementation(libs.leakCanary.android)
+    stagingImplementation(libs.leakCanary.android)
 
- debugImplementation(libs.leakCanary.android)
+    debugImplementation(libs.leakCanary.android)
 
- baselineProfile(projects.wearBaselineProfileGenerator)
+    baselineProfile(projects.wearBaselineProfileGenerator)
 }
 
 dependencyGuard {

--- a/web-app/build.gradle.kts
+++ b/web-app/build.gradle.kts
@@ -50,31 +50,31 @@ kotlin {
         val commonMain by getting {
             val composeBom = project.dependencies.platform(libs.androidx.compose.bom)
             dependencies {
-   implementation(composeBom)
-   implementation(libs.androidx.compose.runtime)
-   implementation(libs.androidx.compose.runtime.retain)
-   implementation(libs.jetbrains.compose.ui)
-   implementation(libs.kotlinx.serialization.core)
-   implementation(projects.data)
-   implementation(projects.database)
-   implementation(projects.filesystem)
-   implementation(projects.imageLoader)
-   implementation(projects.injectScopes)
-   implementation(projects.logging)
-   implementation(projects.network)
-   implementation(projects.preferences)
-   implementation(projects.uiApp)
-   implementation(projects.uiMobile)
-   implementation(projects.updatable)
-  }
+                implementation(composeBom)
+                implementation(libs.androidx.compose.runtime)
+                implementation(libs.androidx.compose.runtime.retain)
+                implementation(libs.jetbrains.compose.ui)
+                implementation(libs.kotlinx.serialization.core)
+                implementation(projects.data)
+                implementation(projects.database)
+                implementation(projects.filesystem)
+                implementation(projects.imageLoader)
+                implementation(projects.injectScopes)
+                implementation(projects.logging)
+                implementation(projects.network)
+                implementation(projects.preferences)
+                implementation(projects.uiApp)
+                implementation(projects.uiMobile)
+                implementation(projects.updatable)
+            }
         }
         val wasmJsMain by getting {
             configurations["kspWasmJs"].dependencies.addAll(listOf(
                 projects.sealedEnum.ksp,
             ))
             dependencies {
-   implementation(libs.sqldelightAndroidXDriver.opfs)
-  }
+                implementation(libs.sqldelightAndroidXDriver.opfs)
+            }
         }
     }
 


### PR DESCRIPTION
## Description
Fixes incorrect indentation in dependency declarations across `build.gradle.kts` files (`algorithm-benchmark`, `app`, `wear`, and `web-app`) to conform to standard 4-space indentation nesting. Only formatting is affected.

## Changes
- `algorithm-benchmark/build.gradle.kts`: Fix dependencies block indentation to 4 spaces.
- `app/build.gradle.kts`: Fix dependencies block indentation to 4 spaces.
- `wear/build.gradle.kts`: Fix dependencies block indentation to 4 spaces.
- `web-app/build.gradle.kts`: Fix `commonMain.dependencies` and `wasmJsMain.dependencies` indentation to 16 spaces (closing brace to 12 spaces).